### PR TITLE
Persist speaker start/end times in activity data

### DIFF
--- a/config/schema/activities.json
+++ b/config/schema/activities.json
@@ -4,7 +4,9 @@
     {
       "no": "",
       "topic": "",
-      "name": ""
+      "name": "",
+      "start_time": "",
+      "end_time": ""
     }
   ],
   "activities_contacts": [

--- a/data/activities/activities_data.json
+++ b/data/activities/activities_data.json
@@ -7,27 +7,37 @@
       {
         "no": 1,
         "topic": "致詞與大合照",
-        "name": "TBD"
+        "name": "TBD",
+        "start_time": "10:00",
+        "end_time": "10:25"
       },
       {
         "no": 2,
         "topic": "再生醫療製劑管理政策",
-        "name": "林奕汝"
+        "name": "林奕汝",
+        "start_time": "10:25",
+        "end_time": "10:50"
       },
       {
         "no": 3,
         "topic": "多元CAR-T平台推動個人化免疫治療新紀元",
-        "name": "官建村"
+        "name": "官建村",
+        "start_time": "10:50",
+        "end_time": "11:15"
       },
       {
         "no": 4,
         "topic": "再生醫療產品新進展與台灣合作新契機【英語演講】",
-        "name": "中山功一"
+        "name": "中山功一",
+        "start_time": "11:25",
+        "end_time": "11:50"
       },
       {
         "no": 5,
         "topic": "綜合討論",
-        "name": "所有講者"
+        "name": "所有講者",
+        "start_time": "11:50",
+        "end_time": "12:15"
       }
     ],
     "activities_contacts": [
@@ -56,22 +66,30 @@
       {
         "no": 1,
         "topic": "從新藥開發到臨床應用：打造亞洲生醫產業合作新格局",
-        "name": "王玲美"
+        "name": "王玲美",
+        "start_time": "10:10",
+        "end_time": "10:35"
       },
       {
         "no": 2,
         "topic": "臺灣生醫產業海外市場鏈結現況與展望",
-        "name": "楊家琳"
+        "name": "楊家琳",
+        "start_time": "10:35",
+        "end_time": "11:00"
       },
       {
         "no": 3,
         "topic": "中之島Qross的生醫產業布局與國際合作商機",
-        "name": "澤芳樹"
+        "name": "澤芳樹",
+        "start_time": "11:10",
+        "end_time": "11:35"
       },
       {
         "no": 4,
         "topic": "綜合討論",
-        "name": "所有講者"
+        "name": "所有講者",
+        "start_time": "11:35",
+        "end_time": "12:00"
       }
     ],
     "activities_contacts": [
@@ -100,32 +118,44 @@
       {
         "no": 1,
         "topic": "人體試驗委員會的角色與審查會議的過程",
-        "name": "陳書毓"
+        "name": "陳書毓",
+        "start_time": "09:55",
+        "end_time": "10:45"
       },
       {
         "no": 2,
         "topic": "性別意識對臨床試驗的影響",
-        "name": "陳書毓"
+        "name": "陳書毓",
+        "start_time": "10:55",
+        "end_time": "11:45"
       },
       {
         "no": 3,
         "topic": "人體研究之利益衝突及其管理",
-        "name": "蘇矢立"
+        "name": "蘇矢立",
+        "start_time": "11:45",
+        "end_time": "12:35"
       },
       {
         "no": 4,
         "topic": "藥品臨床試驗之收案、執行與管理(含受試者同意書撰寫)",
-        "name": "張杏焄"
+        "name": "張杏焄",
+        "start_time": "13:35",
+        "end_time": "14:25"
       },
       {
         "no": 5,
         "topic": "臨床試驗研究計畫書撰寫注意事項與審查重點",
-        "name": "張正雄"
+        "name": "張正雄",
+        "start_time": "14:35",
+        "end_time": "15:25"
       },
       {
         "no": 6,
         "topic": "藥品臨床試驗相關統計學",
-        "name": "蕭金福"
+        "name": "蕭金福",
+        "start_time": "15:25",
+        "end_time": "16:15"
       }
     ],
     "activities_contacts": [

--- a/scripts/actions/generate_agenda.py
+++ b/scripts/actions/generate_agenda.py
@@ -88,12 +88,17 @@ def gen_agenda_rows(event: Dict[str, Any]) -> List[Dict[str, str]]:
     # 每一位講者 + 之後可能的 special
     for sp in event["speakers"]:
         end = add_minutes(current, cfg["speaker_minutes"])
+        start_str = current.strftime('%H:%M')
+        end_str = end.strftime('%H:%M')
         rows.append({
             "kind": "talk",
-            "time": f"{current.strftime('%H:%M')}-{end.strftime('%H:%M')}",
+            "time": f"{start_str}-{end_str}",
             "title": sp["topic"],
             "speaker": sp.get("name", "")
         })
+        # 回填到 speaker
+        sp["start_time"] = start_str
+        sp["end_time"] = end_str
         current = end
 
         for s in cfg["special_sessions"]:

--- a/scripts/actions/parse_agenda_docx.py
+++ b/scripts/actions/parse_agenda_docx.py
@@ -148,6 +148,8 @@ def parse_agenda(docx_path: Path, event_name: str) -> Dict[str, Any]:
             "no": talk_idx,
             "topic": topic_text if topic_text else "(未命名主題)",
             "name": speaker_text,
+            "start_time": time_rng[0],
+            "end_time": time_rng[1],
         })
         timeline.append(("talk", talk_idx))
 


### PR DESCRIPTION
## Summary
- capture start/end times when parsing agenda DOCX and when generating agendas
- extend activities schema and data with speaker start/end fields
- use stored times in build_mapping, falling back to computed values
- merge influencer data before speaker fields to avoid overwriting speaker info

## Testing
- `pytest`
- `python scripts/core/check_json.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'data\\shared\\program_data.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a04a9f157c8331a0c99d99e7a30c9c