### PR TITLE
Populate program speakers from activities data

### DIFF
--- a/data/shared/program_data.json
+++ b/data/shared/program_data.json
@@ -42,7 +42,43 @@
       ]
     },
     "max_capacity": 70,
-    "speakers": [],
+    "speakers": [
+      {
+        "no": 1,
+        "topic": "致詞與大合照",
+        "name": "TBD",
+        "start_time": "10:00",
+        "end_time": "10:25"
+      },
+      {
+        "no": 2,
+        "topic": "再生醫療製劑管理政策",
+        "name": "林奕汝",
+        "start_time": "10:25",
+        "end_time": "10:50"
+      },
+      {
+        "no": 3,
+        "topic": "多元CAR-T平台推動個人化免疫治療新紀元",
+        "name": "官建村",
+        "start_time": "10:50",
+        "end_time": "11:15"
+      },
+      {
+        "no": 4,
+        "topic": "再生醫療產品新進展與台灣合作新契機【英語演講】",
+        "name": "中山功一",
+        "start_time": "11:25",
+        "end_time": "11:50"
+      },
+      {
+        "no": 5,
+        "topic": "綜合討論",
+        "name": "所有講者",
+        "start_time": "11:50",
+        "end_time": "12:15"
+      }
+    ],
     "activities_contacts": []
   },
   {
@@ -174,7 +210,50 @@
         }
       ]
     },
-    "speakers": [],
+    "speakers": [
+      {
+        "no": 1,
+        "topic": "人體試驗委員會的角色與審查會議的過程",
+        "name": "陳書毓",
+        "start_time": "09:55",
+        "end_time": "10:45"
+      },
+      {
+        "no": 2,
+        "topic": "性別意識對臨床試驗的影響",
+        "name": "陳書毓",
+        "start_time": "10:55",
+        "end_time": "11:45"
+      },
+      {
+        "no": 3,
+        "topic": "人體研究之利益衝突及其管理",
+        "name": "蘇矢立",
+        "start_time": "11:45",
+        "end_time": "12:35"
+      },
+      {
+        "no": 4,
+        "topic": "藥品臨床試驗之收案、執行與管理(含受試者同意書撰寫)",
+        "name": "張杏焄",
+        "start_time": "13:35",
+        "end_time": "14:25"
+      },
+      {
+        "no": 5,
+        "topic": "臨床試驗研究計畫書撰寫注意事項與審查重點",
+        "name": "張正雄",
+        "start_time": "14:35",
+        "end_time": "15:25"
+      },
+      {
+        "no": 6,
+        "topic": "藥品臨床試驗相關統計學",
+        "name": "蕭金福",
+        "start_time": "15:25",
+        "end_time": "16:15"
+      }
+    ],
     "activities_contacts": []
   },
   {
@@ -218,7 +297,36 @@
       ]
     },
     "max_capacity": 70,
-    "speakers": [],
+    "speakers": [
+      {
+        "no": 1,
+        "topic": "從新藥開發到臨床應用：打造亞洲生醫產業合作新格局",
+        "name": "王玲美",
+        "start_time": "10:10",
+        "end_time": "10:35"
+      },
+      {
+        "no": 2,
+        "topic": "臺灣生醫產業海外市場鏈結現況與展望",
+        "name": "楊家琳",
+        "start_time": "10:35",
+        "end_time": "11:00"
+      },
+      {
+        "no": 3,
+        "topic": "中之島Qross的生醫產業布局與國際合作商機",
+        "name": "澤芳樹",
+        "start_time": "11:10",
+        "end_time": "11:35"
+      },
+      {
+        "no": 4,
+        "topic": "綜合討論",
+        "name": "所有講者",
+        "start_time": "11:35",
+        "end_time": "12:00"
+      }
+    ],
     "activities_contacts": []
   },
   {
@@ -308,7 +416,36 @@
       "speaker_minutes": null,
       "special_sessions": []
     },
-    "speakers": [],
+    "speakers": [
+      {
+        "no": 1,
+        "topic": "從新藥開發到臨床應用：打造亞洲生醫產業合作新格局",
+        "name": "王玲美",
+        "start_time": "10:10",
+        "end_time": "10:35"
+      },
+      {
+        "no": 2,
+        "topic": "臺灣生醫產業海外市場鏈結現況與展望",
+        "name": "楊家琳",
+        "start_time": "10:35",
+        "end_time": "11:00"
+      },
+      {
+        "no": 3,
+        "topic": "中之島Qross的生醫產業布局與國際合作商機",
+        "name": "澤芳樹",
+        "start_time": "11:10",
+        "end_time": "11:35"
+      },
+      {
+        "no": 4,
+        "topic": "綜合討論",
+        "name": "所有講者",
+        "start_time": "11:35",
+        "end_time": "12:00"
+      }
+    ],
     "activities_contacts": []
   },
   {
@@ -337,7 +474,43 @@
       "speaker_minutes": null,
       "special_sessions": []
     },
-    "speakers": [],
+    "speakers": [
+      {
+        "no": 1,
+        "topic": "致詞與大合照",
+        "name": "TBD",
+        "start_time": "10:00",
+        "end_time": "10:25"
+      },
+      {
+        "no": 2,
+        "topic": "再生醫療製劑管理政策",
+        "name": "林奕汝",
+        "start_time": "10:25",
+        "end_time": "10:50"
+      },
+      {
+        "no": 3,
+        "topic": "多元CAR-T平台推動個人化免疫治療新紀元",
+        "name": "官建村",
+        "start_time": "10:50",
+        "end_time": "11:15"
+      },
+      {
+        "no": 4,
+        "topic": "再生醫療產品新進展與台灣合作新契機【英語演講】",
+        "name": "中山功一",
+        "start_time": "11:25",
+        "end_time": "11:50"
+      },
+      {
+        "no": 5,
+        "topic": "綜合討論",
+        "name": "所有講者",
+        "start_time": "11:50",
+        "end_time": "12:15"
+      }
+    ],
     "activities_contacts": []
   },
   {

--- a/scripts/core/check_json.py
+++ b/scripts/core/check_json.py
@@ -1,7 +1,15 @@
 
-import json, pathlib
-p=pathlib.Path(r"data\shared\program_data.json")
-s=p.read_text(encoding="utf-8")
+"""Validate that program_data.json contains valid JSON."""
+
+from pathlib import Path
+import json
+
+
+# Cross-platform path construction
+p = Path("data") / "shared" / "program_data.json"
+
+# Read the file and attempt to parse as JSON
+s = p.read_text(encoding="utf-8")
 try:
     json.loads(s)
     print("OK, length:", len(s))


### PR DESCRIPTION
## Summary
- Fill `program_data.json` with speaker lists moved from activities data.
- Make `check_json.py` cross-platform by constructing the path with `pathlib`.

## Testing
- `python scripts/core/check_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68a431307a8c8331bd9ae2ecdcd7e07e