### PR TITLE
refactor: render template directly from raw data

### DIFF
--- a/scripts/actions/render_with_chrome.py
+++ b/scripts/actions/render_with_chrome.py
@@ -12,7 +12,9 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import Environment, FileSystemLoader, select_autoescape, StrictUndefined
+from jinja2.exceptions import UndefinedError
+import traceback
 
 # Direct import from bootstrap (requested "direct" style)
 from scripts.core.bootstrap import TEMPLATE_DIR, OUTPUT_DIR, DATA_DIR, CHROME_BIN
@@ -24,7 +26,7 @@ INFLUENCER_FILE = DATA_DIR / "shared" / "influencer_data.json"
 # Ensure output directory exists
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-# Load program and influencer data (be tolerant of dict vs list)
+# Load program and influencer data (expect list or dict)
 try:
     with DATA_FILE.open("r", encoding="utf-8") as fh:
         programs_raw = json.load(fh)
@@ -39,35 +41,28 @@ except Exception as e:
     print(f"Failed to load influencer data file {INFLUENCER_FILE}: {e}", file=sys.stderr)
     influencer_list = []
 
-# Normalize programs into a list of program dicts
-if isinstance(programs_raw, dict):
-    if "programs" in programs_raw and isinstance(programs_raw["programs"], list):
-        program_list = programs_raw["programs"]
-    else:
-        program_list = [programs_raw]
-elif isinstance(programs_raw, list):
-    program_list = programs_raw
-else:
-    print(f"Unexpected JSON structure in {DATA_FILE} (expected list or dict).", file=sys.stderr)
-    sys.exit(1)
-
-# Select program entry
+# Select program entry and normalize to a dict
 parser = argparse.ArgumentParser(description="Render program handbook")
 parser.add_argument("--event-id", type=int, default=None, help="Program id to render")
 args = parser.parse_args()
 
-selected = None
-if args.event_id is not None:
-    for prog in program_list:
-        try:
-            if int(prog.get("id", -1)) == args.event_id:
-                selected = prog
-                break
-        except Exception:
-            continue
-
-if selected is None:
-    selected = program_list[0] if program_list else {}
+program_data = {}
+if isinstance(programs_raw, list):
+    if args.event_id is not None:
+        for prog in programs_raw:
+            try:
+                if int(prog.get("id", -1)) == args.event_id:
+                    program_data = prog
+                    break
+            except Exception:
+                continue
+    if not program_data and programs_raw:
+        program_data = programs_raw[0]
+elif isinstance(programs_raw, dict):
+    program_data = programs_raw
+else:
+    print(f"Unexpected JSON structure in {DATA_FILE} (expected list or dict).", file=sys.stderr)
+    sys.exit(1)
 
 # Build schedule from agenda settings
 def build_schedule(event):
@@ -115,7 +110,7 @@ def build_schedule(event):
 infl_by_name = {p.get("name"): p for p in influencer_list if isinstance(p, dict)}
 chairs = []
 speakers = []
-for sp in selected.get("speakers", []) or []:
+for sp in program_data.get("speakers", []) or []:
     name = sp.get("name")
     info = infl_by_name.get(name, {}) or {}
     enriched = {
@@ -129,23 +124,15 @@ for sp in selected.get("speakers", []) or []:
     else:
         speakers.append(enriched)
 
-program_data = {
-    "title": (selected.get("eventNames") or [""])[0] if selected.get("eventNames") else selected.get("title", ""),
-    "date": selected.get("date", ""),
-    "locations": selected.get("locations", []),
-    "organizers": selected.get("organizers", []),
-    "co_organizers": selected.get("coOrganizers", []),
-    "schedule": build_schedule(selected),
-    "chairs": chairs,
-    "speakers": speakers,
-    # "notes": selected.get("notes", []),
-    "contact": selected.get("contact", ""),
-}
+program_data["schedule"] = build_schedule(program_data)
+program_data["chairs"] = chairs
+program_data["speakers"] = speakers
 
 # Prepare Jinja2 environment
 env = Environment(
     loader=FileSystemLoader(str(TEMPLATE_DIR)),
     autoescape=select_autoescape(["html", "xml"]),
+    undefined=StrictUndefined,
 )
 
 try:
@@ -154,15 +141,13 @@ except Exception as e:
     print(f"Template not found in {TEMPLATE_DIR}: {e}", file=sys.stderr)
     sys.exit(1)
 
-# Render HTML with consistent context variable name: program_data
+# Render HTML directly with raw program data
 try:
-    context = {
-        "program_data": program_data,
-        "organizers": program_data.get("organizers", []),
-        "co_organizers": program_data.get("co_organizers", []),
-        "assets": {},
-    }
-    html = tpl.render(**context)
+    html = tpl.render(**program_data, assets={})
+except UndefinedError as e:
+    print("Template rendering failed due to missing variable:", file=sys.stderr)
+    traceback.print_exc()
+    sys.exit(1)
 except Exception as e:
     print(f"Template rendering failed: {e}", file=sys.stderr)
     sys.exit(1)

--- a/templates/template.html
+++ b/templates/template.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>{{ program_data.title or "論壇手冊" }}</title>
+    <title>{{ (eventNames[0] if eventNames) or "論壇手冊" }}</title>
 
     <style>
         /* A4 印刷基礎 */
@@ -112,11 +112,11 @@ img { max-width: 100%; height: auto; }
     {% if assets.logo_url %}
     <img src="{{ assets.logo_url }}" alt="logo" style="max-height:90px; margin-bottom:8px;">
     {% endif %}
-    <div class="title">{{ program_data.title }}</div>
-    <div class="meta">{{ program_data.date }} | {{ program_data.locations[0] }}</div>
+    <div class="title">{{ eventNames[0] }}</div>
+    <div class="meta">{{ date }} | {{ locations[0] }}</div>
     <div style="margin-top:12px; font-size:11pt; color:#555;">
         主辦：{{ organizers | join('、') }}<br/>
-        協辦：{{ co_organizers | join('、') }}
+        協辦：{{ coOrganizers | join('、') }}
     </div>
 </div>
 
@@ -135,23 +135,25 @@ img { max-width: 100%; height: auto; }
 <!-- 論壇資訊（整頁：若資訊過少仍保留空白讓它佔一頁） -->
 <section class="page-full forum-info" aria-label="論壇資訊 Forum Info">
     <h2>論壇資訊 / Forum Info</h2>
-    <p><strong>名稱 / Title：</strong> {{ program_data.title }}</p>
-    <p><strong>日期 / Date：</strong> {{ program_data.date }}</p>
-    <p><strong>地點 / Venue：</strong> {{ program_data.locations[0] }}</p>
-    <p><strong>地點 / Venue：</strong> {{ program_data.locations[1] }}</p>
-    <p><strong>主辦單位 / Organizer：</strong> {{ program_data.organizers | join('、') }}</p>
-    <p><strong>協辦單位 / Co-organizer：</strong> {{ program_data.co_organizers | join('、') }}</p>
-    {% if program_data.contact %}
-    <p><strong>聯絡 / Contact：</strong> {{ program_data.contact }}</p>
+    <p><strong>名稱 / Title：</strong> {{ eventNames[0] }}</p>
+    <p><strong>日期 / Date：</strong> {{ date }}</p>
+    <p><strong>地點 / Venue：</strong> {{ locations[0] }}</p>
+    {% if locations|length > 1 %}
+    <p><strong>地點 / Venue：</strong> {{ locations[1] }}</p>
+    {% endif %}
+    <p><strong>主辦單位 / Organizer：</strong> {{ organizers | join('、') }}</p>
+    <p><strong>協辦單位 / Co-organizer：</strong> {{ coOrganizers | join('、') }}</p>
+    {% if activities_contacts is defined and activities_contacts %}
+    <p><strong>聯絡 / Contact：</strong> {{ activities_contacts | join('、') }}</p>
     {% endif %}
 </section>
 
 <!-- 論壇須知（整頁） -->
 <section class="page-full notes" aria-label="論壇須知 Notes">
     <h2>論壇須知 / Notes</h2>
-    {% if program_data.notes %}
+    {% if notes is defined and notes %}
     <ul>
-        {% for note in program_data.notes %}
+        {% for note in notes %}
         <li>{{ note }}</li>
         {% endfor %}
     </ul>
@@ -173,7 +175,7 @@ img { max-width: 100%; height: auto; }
         </tr>
         </thead>
         <tbody>
-        {% for item in program_data.schedule %}
+        {% for item in schedule %}
         <tr>
             <td>{{ item.time }}</td>
             <td>{{ item.topic }}</td>
@@ -186,7 +188,7 @@ img { max-width: 100%; height: auto; }
 </section>
 
 <!-- 主持人：每位主持人各一頁 -->
-{% for chair in program_data.chairs %}
+{% for chair in chairs %}
 <section class="page-full" aria-label="主持人 Chair">
     <h2>主持人 / Chair</h2>
     <div class="person-card">
@@ -195,15 +197,15 @@ img { max-width: 100%; height: auto; }
         {% endif %}
         <div class="person-info">
             <div class="name">{{ chair.name }}</div>
-            <div class="title">{{ chair.position }}</div>
-            <div class="bio">{{ chair.bio or "" }}</div>
+            <div class="title">{{ chair.title }}</div>
+            <div class="bio">{{ chair.profile or "" }}</div>
         </div>
     </div>
 </section>
 {% endfor %}
 
 <!-- 講者：每位講者各一頁 -->
-{% for sp in program_data.speakers %}
+{% for sp in speakers %}
 <section class="page-full" aria-label="講者 Speaker">
     <h2>講者 / Speaker</h2>
     <div class="person-card">


### PR DESCRIPTION
## Summary
- render program handbook using raw JSON data without manual remapping
- fail fast when templates reference unknown variables

## Testing
- `python scripts/actions/render_with_chrome.py --event-id 2` *(fails: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_68a9832c59e88331bbd158ed89d29b52