### PR TITLE
Fix Python2 issues in render_with_chrome

### DIFF
--- a/scripts/actions/render_with_chrome.py
+++ b/scripts/actions/render_with_chrome.py
@@ -160,7 +160,9 @@ except TemplateNotFound as e:
 
 # Render HTML directly with raw program data
 try:
-    html = tpl.render(**program_data, assets={})
+    render_args = dict(program_data)
+    render_args["assets"] = {}
+    html = tpl.render(**render_args)
 except UndefinedError:
     print("Template rendering failed due to missing variable:", file=sys.stderr)
     traceback.print_exc()

--- a/scripts/core/bootstrap.py
+++ b/scripts/core/bootstrap.py
@@ -4,7 +4,11 @@ import csv
 import os
 import shutil
 import platform
-from pathlib import Path
+
+try:  # Python 2 fallback
+    from pathlib import Path
+except ImportError:  # pragma: no cover - fallback for legacy Python
+    from pathlib2 import Path  # type: ignore
 from typing import Optional
 
 # Project root


### PR DESCRIPTION
## Summary
- Avoid Python 2 keyword argument ordering issue in render_with_chrome
- Allow bootstrap to fall back to pathlib2 when pathlib is missing

## Testing
- `python -m py_compile scripts/actions/render_with_chrome.py scripts/core/bootstrap.py`

------
https://chatgpt.com/codex/tasks/task_e_68a996ae874c8331a6e8eb274af8825f