### PR TITLE
Replace f-strings and rename shadowed loop variables

### DIFF
--- a/scripts/actions/generate_agenda.py
+++ b/scripts/actions/generate_agenda.py
@@ -34,7 +34,7 @@ def pick_event(programs: List[Dict[str, Any]], event_name: str) -> Dict[str, Any
         names = prog.get("eventNames") or []
         if any(event_name == n for n in names):
             return prog
-    raise SystemExit(f"找不到 event：{event_name}")
+    raise SystemExit("找不到 event：{}".format(event_name))
 
 # ---------- time helpers ----------
 def distribute_empty_durations(cfg: Dict[str, Any], speaker_count: int) -> Dict[str, Any]:
@@ -54,14 +54,14 @@ def distribute_empty_durations(cfg: Dict[str, Any], speaker_count: int) -> Dict[
 
     remaining = total_minutes - total_known
     if remaining < 0:
-        print(f"[警告] 總時數不足，缺 {-remaining} 分鐘（請調整 speaker_minutes 或 special_sessions）")
+        print("[警告] 總時數不足，缺 {} 分鐘（請調整 speaker_minutes 或 special_sessions）".format(-remaining))
         remaining = 0
 
     if empty_items:
         avg = round(remaining / len(empty_items)) if len(empty_items) else 0
         for s in empty_items:
             s["duration"] = max(0, avg)
-        print(f"[INFO] 自動分配空白時段：總剩餘 {remaining} 分鐘，平均每段 {avg} 分鐘")
+        print("[INFO] 自動分配空白時段：總剩餘 {} 分鐘，平均每段 {} 分鐘".format(remaining, avg))
     return cfg
 
 def gen_agenda_rows(event: Dict[str, Any]) -> List[Dict[str, str]]:
@@ -79,7 +79,7 @@ def gen_agenda_rows(event: Dict[str, Any]) -> List[Dict[str, str]]:
             end = add_minutes(current, s["duration"])
             rows.append({
                 "kind": "special",
-                "time": f"{current.strftime('%H:%M')}-{end.strftime('%H:%M')}",
+                "time": "{}-{}".format(current.strftime('%H:%M'), end.strftime('%H:%M')),
                 "title": s["title"],
                 "speaker": ""
             })
@@ -92,7 +92,7 @@ def gen_agenda_rows(event: Dict[str, Any]) -> List[Dict[str, str]]:
         end_str = end.strftime('%H:%M')
         rows.append({
             "kind": "talk",
-            "time": f"{start_str}-{end_str}",
+            "time": "{}-{}".format(start_str, end_str),
             "title": sp["topic"],
             "speaker": sp.get("name", "")
         })
@@ -106,7 +106,7 @@ def gen_agenda_rows(event: Dict[str, Any]) -> List[Dict[str, str]]:
                 end2 = add_minutes(current, s["duration"])
                 rows.append({
                     "kind": "special",
-                    "time": f"{current.strftime('%H:%M')}-{end2.strftime('%H:%M')}",
+                "time": "{}-{}".format(current.strftime('%H:%M'), end2.strftime('%H:%M')),
                     "title": s["title"],
                     "speaker": ""
                 })
@@ -118,7 +118,7 @@ def gen_agenda_rows(event: Dict[str, Any]) -> List[Dict[str, str]]:
             end = add_minutes(current, s["duration"])
             rows.append({
                 "kind": "special",
-                "time": f"{current.strftime('%H:%M')}-{end.strftime('%H:%M')}",
+                "time": "{}-{}".format(current.strftime('%H:%M'), end.strftime('%H:%M')),
                 "title": s["title"],
                 "speaker": ""
             })
@@ -144,7 +144,7 @@ def ensure_page_setup(doc: Document):
 def set_cell_shading(cell, fill_rgb_tuple: Tuple[int, int, int]):
     """設定表格儲存格底色（用 6 碼 hex）"""
     r, g, b = fill_rgb_tuple
-    hexcolor = f"{r:02X}{g:02X}{b:02X}"
+    hexcolor = "{:02X}{:02X}{:02X}".format(r, g, b)
     tc_pr = cell._tc.get_or_add_tcPr()
     shd = OxmlElement('w:shd')
     shd.set(qn('w:val'), 'clear')
@@ -202,14 +202,14 @@ def add_agenda_table(doc: Document, rows: List[Dict[str, str]], title: str | Non
             # 內容：主題 + 換行 + 講者
             topic = r["title"].strip()
             name  = r["speaker"].strip()
-            content = topic if not name else f"{topic}\n{name}"
+            content = topic if not name else "{}\n{}".format(topic, name)
             set_cell_text(tr[1], content, align=WD_ALIGN_PARAGRAPH.LEFT)
 
     # 邊框（細線）
     tbl_pr = table._tbl.get_or_add_tblPr()
     tbl_borders = OxmlElement('w:tblBorders')
     for tag in ('top', 'left', 'bottom', 'right', 'insideH', 'insideV'):
-        el = OxmlElement(f'w:{tag}')
+        el = OxmlElement('w:{}'.format(tag))
         el.set(qn('w:val'), 'single')
         el.set(qn('w:sz'), '6')       # 0.5pt
         el.set(qn('w:space'), '0')
@@ -228,7 +228,7 @@ def export_agenda_docx(event: Dict[str, Any], out_path: Path):
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     doc.save(out_path)
-    print(f"[OK] 已輸出：{out_path}")
+    print("[OK] 已輸出：{}".format(out_path))
 
 # ---------- main ----------
 if __name__ == "__main__":

--- a/scripts/actions/mail_template_utils.py
+++ b/scripts/actions/mail_template_utils.py
@@ -131,7 +131,7 @@ def find_template_file(template_filename: str, template_dir: Optional[Path] = No
     matches = list(Path(template_dir).rglob(template_filename))
     if matches:
         return matches[0]
-    raise FileNotFoundError(f"找不到模板：{template_filename}（已搜尋 {template_dir} 及子資料夾）")
+    raise FileNotFoundError("找不到模板：{}（已搜尋 {} 及子資料夾）".format(template_filename, template_dir))
 
 
 # -------------------- helpers: date formatting & highlight wrapper --------------------
@@ -155,9 +155,9 @@ def format_chinese_date(value: Any) -> str:
         except Exception:
             # try common formats
             fmts = ["%Y-%m-%d", "%Y/%m/%d", "%Y%m%d", "%Y.%m.%d", "%Y %m %d"]
-            for f in fmts:
+            for fmt in fmts:
                 try:
-                    dt = datetime.strptime(s, f).date()
+                    dt = datetime.strptime(s, fmt).date()
                     break
                 except Exception:
                     continue
@@ -167,12 +167,12 @@ def format_chinese_date(value: Any) -> str:
     # weekday: Monday=0 -> 一 ... Sunday=6 -> 日
     wmap = ["一", "二", "三", "四", "五", "六", "日"]
     weekday_char = wmap[dt.weekday()] if 0 <= dt.weekday() <= 6 else ""
-    return f"{dt.year}年{dt.month}月{dt.day}日(星期{weekday_char})"
+    return "{}年{}月{}日(星期{})".format(dt.year, dt.month, dt.day, weekday_char)
 
 
 def _wrap_highlight(s: str) -> str:
     """Wrap s with internal highlight markers."""
-    return f"{_HL_START}{s}{_HL_END}"
+    return "{}{}{}".format(_HL_START, s, _HL_END)
 
 
 # -------------------- core: render docx template / body --------------------
@@ -213,10 +213,10 @@ def render_docx_template(template_path: Path, out_path: Path, mapping: Dict[str,
                 val = mapping.get(key_expr)
             s = "" if val is None else str(val)
             # apply filters
-            for f in parts[1:]:
-                if f in ("cn_date", "cnDate", "format_date"):
+            for flt in parts[1:]:
+                if flt in ("cn_date", "cnDate", "format_date"):
                     s = format_chinese_date(s)
-                elif f in ("hl", "highlight"):
+                elif flt in ("hl", "highlight"):
                     s = _wrap_highlight(s)
                 else:
                     # unknown filter: ignore
@@ -321,10 +321,10 @@ def _resolve_path(mapping: Any, expr: str) -> Optional[Any]:
 
 def _apply_filters_to_value(value: Any, filters: List[str]) -> str:
     s = "" if value is None else str(value)
-    for f in filters:
-        if f in ("cn_date", "cnDate", "format_date"):
+    for fltr in filters:
+        if fltr in ("cn_date", "cnDate", "format_date"):
             s = format_chinese_date(s)
-        elif f in ("hl", "highlight"):
+        elif fltr in ("hl", "highlight"):
             s = _wrap_highlight(s)
         else:
             # unknown filter: ignore

--- a/scripts/actions/make_speaker_letters.py
+++ b/scripts/actions/make_speaker_letters.py
@@ -73,7 +73,7 @@ def make_letters(event_name: str, template_filename: str,
         }
 
         safe_name = m.get("safe_filename") or (m.get("name") or "TBD")
-        out_name = f"{no:02d}_{safe_name}_敬請協助提供CV與簡報.docx"
+        out_name = "{:02d}_{}_敬請協助提供CV與簡報.docx".format(no, safe_name)
         out_path = out_base / out_name
         mail_template_utils.render_docx_template(template_path, out_path, mapping, replacers=REPLACERS)
         results.append(out_path)

--- a/scripts/actions/parse_agenda_docx.py
+++ b/scripts/actions/parse_agenda_docx.py
@@ -71,7 +71,7 @@ END_TITLES = { title for _, title, is_end in SPECIAL_RULES if is_end }
 
 def _match_special_title(topic_text: str, speaker_text: str) -> Tuple[Optional[str], bool]:
     """回傳 (normalized_title, is_end_of_day)；若無匹配則 (None, False)"""
-    hay = f"{_clean_text(topic_text)}\n{_clean_text(speaker_text)}"
+    hay = "{}\n{}".format(_clean_text(topic_text), _clean_text(speaker_text))
     for pat, norm_title, is_end in SPECIAL_RULES:
         if pat.search(hay):
             return norm_title, is_end
@@ -211,4 +211,4 @@ if __name__ == "__main__":
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps([program], ensure_ascii=False, indent=2), encoding="utf-8")
-    print(f"[OK] Wrote {out_path}")
+    print("[OK] Wrote {}".format(out_path))

--- a/scripts/actions/render_to_pdf.py
+++ b/scripts/actions/render_to_pdf.py
@@ -31,8 +31,8 @@ html = tpl.render(**data)
 # save html for preview
 with open(OUT_HTML, "w", encoding="utf8") as f:
     f.write(html)
-print(f"Saved HTML preview to {OUT_HTML}")
+print("Saved HTML preview to {}".format(OUT_HTML))
 
 # render PDF with WeasyPrint
 HTML(string=html, base_url=TEMPLATES_DIR).write_pdf(OUT_PDF)
-print(f"Saved PDF to {OUT_PDF}")
+print("Saved PDF to {}".format(OUT_PDF))

--- a/scripts/actions/replace_docx_with_vars.py
+++ b/scripts/actions/replace_docx_with_vars.py
@@ -36,23 +36,23 @@ def iter_json_records(payload: Any):
     if isinstance(payload, list):
         for i, v in enumerate(payload):
             if isinstance(v, dict):
-                yield (f"[{i}]", v)
+                yield ("[{}]".format(i), v)
     elif isinstance(payload, dict):
         yield ("", payload)
         for k, v in payload.items():
             if isinstance(v, list):
                 for i, item in enumerate(v):
                     if isinstance(item, dict):
-                        yield (f"{k}[{i}]", item)
+                        yield ("{}[{}]".format(k, i), item)
 
 def iter_json_paths(node: Any, base: str = ""):
     if isinstance(node, dict):
         for k, v in node.items():
-            key = f"{base}.{k}" if base else k
+            key = "{}.{}".format(base, k) if base else k
             yield from iter_json_paths(v, key)
     elif isinstance(node, list):
         for i, v in enumerate(node):
-            key = f"{base}[{i}]"
+            key = "{}[{}]".format(base, i)
             yield from iter_json_paths(v, key)
     else:
         yield (base, node)
@@ -119,13 +119,13 @@ def main():
     # 找模板
     t_matches = list(TEMPLATE_DIR.rglob(args.template))
     if not t_matches:
-        raise SystemExit(f"找不到模板：{args.template} 於 {TEMPLATE_DIR} 下")
+        raise SystemExit("找不到模板：{} 於 {} 下".format(args.template, TEMPLATE_DIR))
     input_docx = t_matches[0]
 
     # 找所有同名 JSON
     j_matches = list(DATA_DIR.rglob(args.json_file))
     if not j_matches:
-        raise SystemExit(f"找不到 JSON：{args.json_file} 於 {DATA_DIR} 下")
+        raise SystemExit("找不到 JSON：{} 於 {} 下".format(args.json_file, DATA_DIR))
 
     # 由多個 JSON 檔合併 mapping
     mapping: Dict[str, str] = {}
@@ -134,7 +134,7 @@ def main():
         try:
             payload = json.loads(jf.read_text(encoding="utf-8"))
         except Exception as e:
-            print(f"[WARN] 讀取失敗 {jf}: {e}")
+            print("[WARN] 讀取失敗 {}: {}".format(jf, e))
             continue
 
         # 依使用者條件在檔內挑選一筆（或多筆）record
@@ -178,7 +178,7 @@ def main():
     replace_in_document(doc, mapping, merge_runs_if_needed=args.merge_runs)
     out_path = OUTPUT_DIR / (input_docx.stem + "_template.docx")
     doc.save(out_path)
-    print(f"[OK] 已輸出：{out_path}")
+    print("[OK] 已輸出：{}".format(out_path))
 
 if __name__ == "__main__":
     main()

--- a/scripts/actions/send_program_speaker_emails.py
+++ b/scripts/actions/send_program_speaker_emails.py
@@ -44,11 +44,11 @@ def build_speaker_records(program_id: str) -> List[Dict[str, Any]]:
     program = find_program_by_id(programs, program_id)
 
     if not program:
-        raise ValueError(f"Program id {program_id} not found")
+        raise ValueError("Program id {} not found".format(program_id))
 
     event_names = program.get("eventNames") or []
     if not event_names:
-        raise ValueError(f"Program {program_id} has no eventNames")
+        raise ValueError("Program {} has no eventNames".format(program_id))
     event_name = event_names[0]
 
     mappings = get_event_speaker_mappings(event_name)

--- a/scripts/actions/smtp_test_hardcoded.py
+++ b/scripts/actions/smtp_test_hardcoded.py
@@ -24,7 +24,7 @@ def main():
     msg["Subject"] = SUBJECT
     msg.set_content(BODY)
 
-    print(f"Using SMTP server: {SMTP_SERVER}:{SMTP_PORT}, username: {SMTP_USER}")
+    print("Using SMTP server: {}:{}, username: {}".format(SMTP_SERVER, SMTP_PORT, SMTP_USER))
     try:
         with smtplib.SMTP(SMTP_SERVER, SMTP_PORT, timeout=30) as s:
             s.set_debuglevel(1)   # prints SMTP dialog for debugging

--- a/scripts/core/bootstrap.py
+++ b/scripts/core/bootstrap.py
@@ -57,7 +57,7 @@ def search_file(base_dir: Path, target_filename: str) -> Path:
     for path in base_dir.rglob("*"):
         if path.name == target_filename:
             return path
-    raise FileNotFoundError(f"找不到檔案: {target_filename}")
+    raise FileNotFoundError("找不到檔案: {}".format(target_filename))
 
 def load_schema(filename: str) -> dict:
     path = search_file(BASE_DIR / "config" / "schema", filename)

--- a/scripts/core/build_mapping.py
+++ b/scripts/core/build_mapping.py
@@ -73,7 +73,7 @@ def load_json(name: str) -> Any:
         seen.add(cand)
         if cand.exists():
             return read_json_relaxed(cand)
-    raise FileNotFoundError(f"找不到 {name}")
+    raise FileNotFoundError("找不到 {}".format(name))
 
 
 def compute_times(
@@ -114,7 +114,7 @@ def get_event_speaker_mappings(event_name: str) -> List[Dict[str, Any]]:
 
     program = next((p for p in programs if event_name in (p.get("eventNames") or [])), None)
     if not program:
-        raise ValueError(f"找不到 program: {event_name}")
+        raise ValueError("找不到 program: {}".format(event_name))
 
     infl_map: Dict[str, Dict[str, Any]] = {i.get("name"): i for i in influencers if i.get("name")}
     # fallback: use organization as key
@@ -210,11 +210,11 @@ def get_program_speaker_mappings(
         program = next((p for p in programs if key in (p.get("eventNames") or [])), None)
 
     if not program:
-        raise ValueError(f"找不到 program: {program_id_or_eventname}")
+        raise ValueError("找不到 program: {}".format(program_id_or_eventname))
 
     event_names = program.get("eventNames") or []
     if not event_names:
-        raise ValueError(f"program {program.get('id')} 缺少 eventNames")
+        raise ValueError("program {} 缺少 eventNames".format(program.get('id')))
 
     merged: List[Dict[str, Any]] = []
     seen = set()
@@ -227,7 +227,7 @@ def get_program_speaker_mappings(
         for m in ev_maps:
             key = _norm_key(m.get("name") or m.get("safe_filename") or "")
             if not key:
-                key = _norm_key(f"{m.get('topic')}-{m.get('no')}")
+                key = _norm_key("{}-{}".format(m.get('topic'), m.get('no')))
             if key in seen:
                 continue
             seen.add(key)

--- a/scripts/core/data_util.py
+++ b/scripts/core/data_util.py
@@ -150,7 +150,7 @@ def load_records(path: Path, sheet_name: Optional[str] = None) -> List[Dict[str,
             wb = openpyxl.load_workbook(path, data_only=True)
             if sheet_name:
                 if sheet_name not in wb.sheetnames:
-                    raise ValueError(f"Sheet '{sheet_name}' not found in {path} (available: {wb.sheetnames})")
+                    raise ValueError("Sheet '{}' not found in {} (available: {})".format(sheet_name, path, wb.sheetnames))
                 ws = wb[sheet_name]
             else:
                 ws = wb.active
@@ -162,7 +162,7 @@ def load_records(path: Path, sheet_name: Optional[str] = None) -> List[Dict[str,
             for row in rows[1:]:
                 r = {}
                 for i, val in enumerate(row):
-                    header = headers[i] if i < len(headers) else f"col_{i}"
+                    header = headers[i] if i < len(headers) else "col_{}".format(i)
                     r[header] = val
                 recs.append(r)
             return recs
@@ -171,7 +171,7 @@ def load_records(path: Path, sheet_name: Optional[str] = None) -> List[Dict[str,
             book = xlrd.open_workbook(str(path))
             if sheet_name:
                 if sheet_name not in book.sheet_names():
-                    raise ValueError(f"Sheet '{sheet_name}' not found in {path} (available: {book.sheet_names()})")
+                    raise ValueError("Sheet '{}' not found in {} (available: {})".format(sheet_name, path, book.sheet_names()))
                 sh = book.sheet_by_name(sheet_name)
             else:
                 sh = book.sheet_by_index(0)
@@ -183,11 +183,11 @@ def load_records(path: Path, sheet_name: Optional[str] = None) -> List[Dict[str,
                 rowvals = [sh.cell_value(r, c) for c in range(sh.ncols)]
                 rec = {}
                 for i, val in enumerate(rowvals):
-                    header = headers[i] if i < len(headers) else f"col_{i}"
+                    header = headers[i] if i < len(headers) else "col_{}".format(i)
                     rec[header] = val
                 recs.append(rec)
             return recs
-    raise ValueError(f"Unsupported file extension: {ext}")
+    raise ValueError("Unsupported file extension: {}".format(ext))
 
 
 def load_all_records_from_dir(data_dir: Path, sheet_name: Optional[str] = None) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- replace f-strings with `str.format` across scripts to avoid Python 2.7 `F` prefix errors
- rename loop variable `f` to more descriptive names to prevent shadowing warnings

## Testing
- `python -m py_compile $(git ls-files 'scripts/**/*.py')`
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a99c1af8b483318ae16dd55cf03d10