### PR TITLE
Add schedule table builder and integrate with rendering

### DIFF
--- a/scripts/actions/render_with_chrome.py
+++ b/scripts/actions/render_with_chrome.py
@@ -12,11 +12,12 @@ import sys
 import json
 import subprocess
 import argparse
-from datetime import datetime, timedelta
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+from scripts.actions.schedule_table import build_table
 
 
 # <<<<<<< HEAD
@@ -79,30 +80,6 @@ else:
     print("Unexpected JSON structure in {} (expected list or dict).".format(DATA_FILE), file=sys.stderr)
     sys.exit(1)
 
-# Build schedule by leveraging generate_agenda helper
-def build_schedule(event):
-    """Build schedule rows using generate_agenda's logic.
-
-    This delegates the heavy lifting to ``gen_agenda_rows`` from
-    ``scripts.actions.generate_agenda`` and adapts the returned rows into
-    the structure expected by the rendering pipeline.
-    """
-    try:
-        from scripts.actions.generate_agenda import gen_agenda_rows
-    except Exception:
-        # Fallback to an empty schedule if the helper can't be imported
-        return []
-
-    rows = gen_agenda_rows(event)
-    schedule = []
-    for r in rows:
-        schedule.append({
-            "time": r.get("time", ""),
-            "topic": r.get("title", ""),
-            "speaker": r.get("speaker", ""),
-
-        })
-    return schedule
 
 # Build speaker and chair lists augmented from influencer data
 infl_by_name = {p.get("name"): p for p in influencer_list if isinstance(p, dict)}
@@ -122,7 +99,7 @@ for speaker_entry in program_data.get("speakers", []) or []:
     else:
         speakers.append(enriched)
 
-program_data["schedule"] = build_schedule(program_data)
+program_data["schedule"] = build_table(program_data)
 program_data["chairs"] = chairs
 program_data["speakers"] = speakers
 

--- a/scripts/actions/schedule_table.py
+++ b/scripts/actions/schedule_table.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+from typing import Any, Dict, List
+
+
+def build_table(event: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Build table rows from event speakers.
+
+    Each row dictionary contains:
+        - type: "host", "talk", or "merge" (others/breaks)
+        - time: time string or ""
+        - topic / speaker or content depending on type
+    """
+    rows: List[Dict[str, str]] = []
+    speakers = event.get("speakers", []) or []
+
+    for sp in speakers:
+        sp_type = sp.get("type", "")
+        start = sp.get("start_time") or ""
+        end = sp.get("end_time") or ""
+        time_str = f"{start}-{end}".strip("-") if start or end else ""
+        topic = sp.get("topic", "")
+        name = sp.get("name", "")
+
+        if sp_type == "主持人":
+            # Host row: merge all columns
+            content = "{} {}".format(topic, name).strip()
+            rows.append({
+                "type": "host",
+                "time": time_str,
+                "content": content,
+            })
+        elif sp_type in ("講者", "致詞人"):
+            # Normal row: show topic and speaker separately
+            rows.append({
+                "type": "talk",
+                "time": time_str,
+                "topic": topic,
+                "speaker": name,
+            })
+        else:
+            # Other types treated as break/merged rows
+            content = topic
+            if name:
+                content = f"{topic} {name}".strip()
+            rows.append({
+                "type": "merge",
+                "time": time_str,
+                "content": content,
+            })
+    return rows
+
+
+if __name__ == "__main__":  # simple debug output
+    import json
+    from pathlib import Path
+    from scripts.core.bootstrap import DATA_DIR
+
+    data_file = DATA_DIR / "shared" / "program_data.json"
+    data = json.loads(data_file.read_text(encoding="utf-8"))
+    event = data[0] if isinstance(data, list) else data
+    tbl = build_table(event)
+    print(json.dumps(tbl, ensure_ascii=False, indent=2))

--- a/templates/template.html
+++ b/templates/template.html
@@ -280,20 +280,29 @@ img { max-width: 100%; height: auto; }
     <table class="schedule" role="table" aria-label="議程表">
         <thead>
         <tr>
-            <th style="width:16%;">時間 / Time</th>
-            <th style="width:18%;">主題 / Topic</th>
-            <th style="width:26%;">講者 / Speaker</th>
-            <th>備註 / Note</th>
+            <th style="width:17.2%;">時間 / Time</th>
+            <th style="width:55.2%;">主題 / Topic</th>
+            <th style="width:27.6%;">講者 / Speaker</th>
         </tr>
         </thead>
         <tbody>
         {% for item in schedule %}
+        {% if item.type == 'host' %}
+        <tr>
+            <td colspan="3">{{ item.content }}</td>
+        </tr>
+        {% elif item.type == 'merge' %}
+        <tr>
+            <td>{{ item.time }}</td>
+            <td colspan="2">{{ item.content }}</td>
+        </tr>
+        {% else %}
         <tr>
             <td>{{ item.time }}</td>
             <td>{{ item.topic }}</td>
             <td>{{ item.speaker }}</td>
-            <td>{{ item.note or "" }}</td>
         </tr>
+        {% endif %}
         {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- build `schedule_table` helper to derive table rows from event speakers
- use new table builder in `render_with_chrome` and adjust import path
- render agenda table with 3 columns and merged cells in template

## Testing
- `python -m py_compile scripts/actions/schedule_table.py scripts/actions/render_with_chrome.py`
- `python -m scripts.actions.schedule_table | head -n 20`
- `pip install jinja2` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2d27bc488331a10bb555147ba290