### PR TITLE
Simplify schedule to use speaker data directly

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -293,22 +293,16 @@ img { max-width: 100%; height: auto; }
         </tr>
         </thead>
         <tbody>
-        {% for item in schedule %}
-
-            {% if item.kind == 'host' %}
+        {% for sp in speakers %}
         <tr>
-            <td colspan="3">{{ item.text }}</td>
+            <td>
+                {% if sp.start_time or sp.end_time %}
+                    {{ sp.start_time or '' }}{% if sp.end_time %}-{{ sp.end_time }}{% endif %}
+                {% endif %}
+            </td>
+            <td>{{ sp.topic }}</td>
+            <td>{{ sp.name }}</td>
         </tr>
-            {% elif item.kind == 'break' or item.kind == 'special' %}
-
-        <tr>
-            <td>{{ item.time }}</td>
-            <td colspan="2">{{ item.topic }}{% if item.speaker %}<br>{{ item.speaker }}{% endif %}</td>
-        </tr>
-            {% else %}
-
-            {% endif %}
-
         {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- Drop agenda-building helpers and special session handling
- Build schedule rows directly from provided speakers
- Render speaker list in agenda table

## Testing
- `python -m py_compile scripts/actions/app.py`
- `python scripts/actions/app.py --event-id 0` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6517ec2483318f8f327fc611cc70