### PR TITLE
Handle host and break schedule rows

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -293,16 +293,23 @@ img { max-width: 100%; height: auto; }
         </tr>
         </thead>
         <tbody>
-        {% for sp in speakers %}
+        {% for row in schedule %}
+        {% if row.type == 'host' %}
         <tr>
-            <td>
-                {% if sp.start_time or sp.end_time %}
-                    {{ sp.start_time or '' }}{% if sp.end_time %}-{{ sp.end_time }}{% endif %}
-                {% endif %}
-            </td>
-            <td>{{ sp.topic }}</td>
-            <td>{{ sp.name }}</td>
+            <td colspan="3" style="text-align:center">{{ row.content }}</td>
         </tr>
+        {% elif row.type == 'break' %}
+        <tr>
+            <td>{{ row.time }}</td>
+            <td colspan="2">{{ row.content }}</td>
+        </tr>
+        {% else %}
+        <tr>
+            <td>{{ row.time }}</td>
+            <td>{{ row.topic }}</td>
+            <td>{{ row.speaker }}</td>
+        </tr>
+        {% endif %}
         {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- Merge time/topic/speaker into a single centered cell when topic is `主持`
- Merge topic and speaker columns when topic is `休息`
- Render schedule rows based on new `schedule` list

## Testing
- `python -m py_compile scripts/actions/app.py`
- `python scripts/actions/app_render_to_pdf.py --event-id 2` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*


------
https://chatgpt.com/codex/tasks/task_e_68ac6979c8f4833185789d36f7c44616