### PR TITLE
Add host column and speaker directories

### DIFF
--- a/scripts/actions/app.py
+++ b/scripts/actions/app.py
@@ -144,8 +144,9 @@ def _schedule_from_speakers(program, influencers=None):
             speaker = f"{speaker}\n{org}"
 
         if topic == "主持":
-            content = " ".join(filter(None, [time.replace("\n", " "), topic, speaker]))
-            schedule.append({"type": "host", "content": content})
+            # Host information is rendered separately in the schedule table
+            # as a dedicated column, so skip adding a standalone row here.
+            continue
         elif topic == "休息":
             content = topic if not name or name == topic else f"{topic} {speaker}"
             schedule.append({"type": "break", "time": time, "content": content})

--- a/templates/template.html
+++ b/templates/template.html
@@ -30,7 +30,9 @@
           page-break-after: always;
           page-break-inside: avoid;
           min-height: calc(297mm - 36mm); /* 確保至少一頁 */
-          display: block;
+          display: flex;
+          flex-direction: column;
+          justify-content: space-evenly; /* 若不足一頁，內容均勻分布 */
           padding-top: 10mm;
           padding-bottom: 10mm;
           box-sizing: border-box;
@@ -127,6 +129,14 @@ div[name="參與單位"] { align-self: flex-start; text-align: left; width:100%;
           border:1px solid #ddd; padding:6px 8px; vertical-align:top; font-size:11pt;
         }
         table.schedule th { background:#f3f3f3; font-weight:600; text-align:left; }
+        table.schedule td.host-cell {
+          background:#fbe5d5;
+          text-align:center;
+          vertical-align:middle;
+        }
+
+        .person-list { list-style:none; padding:0; margin:0; }
+        .person-list li { margin-bottom:6px; }
 
         /* 主持人 / 講者頁面樣式 */
         .person-card {
@@ -286,40 +296,71 @@ img { max-width: 100%; height: auto; }
     <table class="schedule" role="table" aria-label="議程表" style="width:17.4cm;">
         <colgroup>
             <col style="width:3.0cm;">
-            <col style="width:9.6cm;">
-            <col style="width:4.8cm;">
+            <col style="width:3.0cm;">
+            <col style="width:7.8cm;">
+            <col style="width:3.6cm;">
         </colgroup>
         <thead>
         <tr>
-
+            <th>主持人 / Host</th>
             <th>時間 / Time</th>
             <th>主題 / Topic</th>
             <th>講者 / Speaker</th>
-
         </tr>
         </thead>
         <tbody>
         {% for row in schedule %}
-        {% if row.type == 'host' %}
         <tr>
-            <td colspan="3" style="text-align:center">{{ row.content }}</td>
-        </tr>
-        {% elif row.type == 'break' %}
-        <tr>
+            {% if loop.first %}
+            <td rowspan="{{ schedule|length }}" class="host-cell">
+                {% for chair in chairs %}
+                    {{ chair.name }}{% if chair.title %} {{ chair.title }}{% endif %}
+                    {% if chair.organization %}<br>{{ chair.organization }}{% endif %}
+                    {% if not loop.last %}<br><br>{% endif %}
+                {% endfor %}
+            </td>
+            {% endif %}
+            {% if row.type == 'break' %}
             <td>{{ row.time }}</td>
             <td colspan="2">{{ row.content }}</td>
-        </tr>
-        {% else %}
-        <tr>
+            {% else %}
             <td>{{ row.time }}</td>
             <td>{{ row.topic }}</td>
             <td>{{ row.speaker }}</td>
+            {% endif %}
         </tr>
-        {% endif %}
         {% endfor %}
         </tbody>
     </table>
 </section>
+
+{% if chairs %}
+<section class="page-full">
+    <h2>主持人 / Chairs</h2>
+    <ul class="person-list">
+    {% for chair in chairs %}
+        <li>
+            {{ chair.name }}{% if chair.title %} {{ chair.title }}{% endif %}
+            {% if chair.organization %}<br>{{ chair.organization }}{% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+</section>
+{% endif %}
+
+{% if speakers %}
+<section class="page-full">
+    <h2>講者 / Speakers</h2>
+    <ul class="person-list">
+    {% for sp in speakers %}
+        <li>
+            {{ sp.name }}{% if sp.title %} {{ sp.title }}{% endif %}
+            {% if sp.organization %}<br>{{ sp.organization }}{% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+</section>
+{% endif %}
 
 <!-- 主持人：每位主持人各一頁 -->
 {% for chair in chairs %}


### PR DESCRIPTION
## Summary
- Show chairs in a dedicated column spanning all schedule rows with highlighted background
- Add overview pages listing all chairs and all speakers with their titles and organizations
- Evenly distribute content on pages when they don't fill the page

## Testing
- `python -m py_compile scripts/actions/app.py`
- `python scripts/actions/app.py --event-id 2` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c7342c88331b893de184f895c07