### PR TITLE
Highlight host rows and add speaker directories

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -30,7 +30,9 @@
           page-break-after: always;
           page-break-inside: avoid;
           min-height: calc(297mm - 36mm); /* 確保至少一頁 */
-          display: block;
+          display: flex;
+          flex-direction: column;
+          justify-content: space-evenly; /* 若不足一頁，內容均勻分布 */
           padding-top: 10mm;
           padding-bottom: 10mm;
           box-sizing: border-box;
@@ -127,6 +129,14 @@ div[name="參與單位"] { align-self: flex-start; text-align: left; width:100%;
           border:1px solid #ddd; padding:6px 8px; vertical-align:top; font-size:11pt;
         }
         table.schedule th { background:#f3f3f3; font-weight:600; text-align:left; }
+        table.schedule td.host-cell {
+          background:#fbe5d5;
+          text-align:center;
+          vertical-align:middle;
+        }
+
+        .person-list { list-style:none; padding:0; margin:0; }
+        .person-list li { margin-bottom:6px; }
 
         /* 主持人 / 講者頁面樣式 */
         .person-card {
@@ -291,18 +301,16 @@ img { max-width: 100%; height: auto; }
         </colgroup>
         <thead>
         <tr>
-
             <th>時間 / Time</th>
             <th>主題 / Topic</th>
             <th>講者 / Speaker</th>
-
         </tr>
         </thead>
         <tbody>
         {% for row in schedule %}
         {% if row.type == 'host' %}
         <tr>
-            <td colspan="3" style="text-align:center">{{ row.content }}</td>
+            <td colspan="3" class="host-cell">{{ row.content }}</td>
         </tr>
         {% elif row.type == 'break' %}
         <tr>
@@ -320,6 +328,34 @@ img { max-width: 100%; height: auto; }
         </tbody>
     </table>
 </section>
+
+{% if chairs %}
+<section class="page-full">
+    <h2>主持人 / Chairs</h2>
+    <ul class="person-list">
+    {% for chair in chairs %}
+        <li>
+            {{ chair.name }}{% if chair.title %} {{ chair.title }}{% endif %}
+            {% if chair.organization %}<br>{{ chair.organization }}{% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+</section>
+{% endif %}
+
+{% if speakers %}
+<section class="page-full">
+    <h2>講者 / Speakers</h2>
+    <ul class="person-list">
+    {% for sp in speakers %}
+        <li>
+            {{ sp.name }}{% if sp.title %} {{ sp.title }}{% endif %}
+            {% if sp.organization %}<br>{{ sp.organization }}{% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+</section>
+{% endif %}
 
 <!-- 主持人：每位主持人各一頁 -->
 {% for chair in chairs %}


### PR DESCRIPTION
## Summary
- Keep schedule layout without an extra host column; highlight host rows with a peach background
- Emit host entries in schedule data again
- Provide overview pages for chairs and speakers listing their names and organizations

## Testing
- `python -m py_compile scripts/actions/app.py`
- `python scripts/actions/app.py --event-id 2` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c7342c88331b893de184f895c07