### PR TITLE
Display host as merged row beneath opening remarks

### DIFF
--- a/scripts/actions/app.py
+++ b/scripts/actions/app.py
@@ -99,7 +99,7 @@ def _normalize_event_names(program):
 def _schedule_from_speakers(program, influencers=None):
     """Build a schedule with merged-column rules.
 
-    - If topic is "主持", merge time/topic/speaker into one cell.
+    - Entries with topic "主持" render as a centered row spanning all columns.
     - If topic is "休息", merge topic and speaker columns.
     - Otherwise keep the three-column layout.
     - Time column includes duration in minutes on a new line.
@@ -144,9 +144,8 @@ def _schedule_from_speakers(program, influencers=None):
             speaker = f"{speaker}\n{org}"
 
         if topic == "主持":
-            # Host information is rendered separately in the schedule table
-            # as a dedicated column, so skip adding a standalone row here.
-            continue
+            content = f"{topic} {speaker}".strip()
+            schedule.append({"type": "host", "content": content})
         elif topic == "休息":
             content = topic if not name or name == topic else f"{topic} {speaker}"
             schedule.append({"type": "break", "time": time, "content": content})

--- a/templates/template.html
+++ b/templates/template.html
@@ -129,11 +129,6 @@ div[name="參與單位"] { align-self: flex-start; text-align: left; width:100%;
           border:1px solid #ddd; padding:6px 8px; vertical-align:top; font-size:11pt;
         }
         table.schedule th { background:#f3f3f3; font-weight:600; text-align:left; }
-        table.schedule td.host-cell {
-          background:#fbe5d5;
-          text-align:center;
-          vertical-align:middle;
-        }
 
         .person-list { list-style:none; padding:0; margin:0; }
         .person-list li { margin-bottom:6px; }
@@ -298,13 +293,11 @@ img { max-width: 100%; height: auto; }
     <table class="schedule" role="table" aria-label="議程表" style="width:17.4cm;">
         <colgroup>
             <col style="width:3.0cm;">
-            <col style="width:3.0cm;">
-            <col style="width:7.8cm;">
+            <col style="width:10.8cm;">
             <col style="width:3.6cm;">
         </colgroup>
         <thead>
         <tr>
-            <th>主持人 / Host</th>
             <th>時間 / Time</th>
             <th>主題 / Topic</th>
             <th>講者 / Speaker</th>
@@ -313,18 +306,11 @@ img { max-width: 100%; height: auto; }
         <tbody>
         {% for row in schedule %}
         <tr>
-            {% if loop.first %}
-            <td rowspan="{{ schedule|length }}" class="host-cell">
-                {% for chair in chairs %}
-                    {{ chair.name }}{% if chair.title %} {{ chair.title }}{% endif %}
-                    {% if chair.organization %}<br>{{ chair.organization }}{% endif %}
-                    {% if not loop.last %}<br><br>{% endif %}
-                {% endfor %}
-            </td>
-            {% endif %}
             {% if row.type == 'break' %}
             <td>{{ row.time }}</td>
             <td colspan="2">{{ row.content }}</td>
+            {% elif row.type == 'host' %}
+            <td colspan="3" style="text-align:center;">{{ row.content }}</td>
             {% else %}
             <td>{{ row.time }}</td>
             <td>{{ row.topic }}</td>


### PR DESCRIPTION
## Summary
- render host entries as centered schedule rows spanning all columns
- handle host rows in template with full-width merged cell

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac8d6eb0d08331acf65058497892cb