### PR TITLE
Align schedule builder with template

### DIFF
--- a/scripts/actions/app.py
+++ b/scripts/actions/app.py
@@ -97,13 +97,19 @@ def _normalize_event_names(program):
 
 
 def _schedule_from_speakers(program, influencers=None):
-    """Build a schedule with merged-column rules.
+    """Build a schedule with merged-column rules matching ``template.html``.
 
-    - Entries with topic "主持" render as a centered row spanning all columns.
-    - If topic is "休息", merge topic and speaker columns.
-    - Otherwise keep the three-column layout.
-    - Time column includes duration in minutes on a new line.
-    - Speaker column includes title and organization pulled from influencer data.
+    The resulting list contains dictionaries with ``kind`` keys used by the
+    template:
+
+    - ``host`` rows span all columns and use ``text`` as their content.
+    - ``break`` rows merge the topic and speaker columns using ``topic`` and
+      optional ``speaker`` values.
+    - ``talk`` rows keep the three-column layout with ``topic`` and ``speaker``.
+
+    In all cases the ``time`` field contains a human readable time range.
+    Speaker information is enriched with title and organization pulled from
+    influencer data.
     """
 
     influencers = influencers or {}
@@ -144,18 +150,27 @@ def _schedule_from_speakers(program, influencers=None):
             speaker = f"{speaker}\n{org}"
 
         if topic == "主持":
-            content = f"{topic} {speaker}".strip()
-            schedule.append({"type": "host", "content": content})
+            text = f"{topic} {speaker}".strip()
+            schedule.append({"kind": "host", "text": text})
         elif topic == "休息":
-            content = topic if not name or name == topic else f"{topic} {speaker}"
-            schedule.append({"type": "break", "time": time, "content": content})
+            speaker_text = "" if not name or name == topic else speaker
+            schedule.append(
+                {
+                    "kind": "break",
+                    "time": time,
+                    "topic": topic,
+                    "speaker": speaker_text,
+                }
+            )
         else:
-            schedule.append({
-                "type": "talk",
-                "time": time,
-                "topic": topic,
-                "speaker": speaker,
-            })
+            schedule.append(
+                {
+                    "kind": "talk",
+                    "time": time,
+                    "topic": topic,
+                    "speaker": speaker,
+                }
+            )
 
     return schedule
 


### PR DESCRIPTION
## Summary
- ensure `_schedule_from_speakers` emits schedule rows with `kind`/`time`/`topic`/`speaker` keys that match `template.html`

## Testing
- `python -m py_compile scripts/actions/app.py`
- `python - <<'PY'\nfrom scripts.actions.app import _schedule_from_speakers\nprogram = {'speakers': [\n    {'topic': '主持', 'start_time': '09:00', 'end_time': '09:10', 'name': '主持人A'},\n    {'topic': '議題1', 'start_time': '09:10', 'end_time': '09:30', 'name': '講者B'},\n    {'topic': '休息', 'start_time': '09:30', 'end_time': '09:40', 'name': '休息'},\n    {'topic': '休息', 'start_time': '09:40', 'end_time': '09:50', 'name': '小張'},\n]}\nres = _schedule_from_speakers(program)\nfor r in res:\n    print(r)\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68ad0aabb2c48331b3e92f400726094b