### PR TITLE
Fix bio rendering by flattening influencer data

### DIFF
--- a/scripts/actions/influencer.py
+++ b/scripts/actions/influencer.py
@@ -1,0 +1,68 @@
+"""Utilities for building speaker/chair information from influencer data."""
+from __future__ import annotations
+from typing import Iterable, Iterator, List, Dict, Tuple
+
+
+def iter_dicts(items: Iterable) -> Iterator[dict]:
+    """Recursively yield dict objects from a nested list structure.
+
+    The influencer JSON mixes lists and objects; this helper flattens the
+    structure so each influencer record can be processed uniformly.
+    """
+    for item in items or []:
+        if isinstance(item, dict):
+            yield item
+        elif isinstance(item, list):
+            for sub in iter_dicts(item):
+                yield sub
+
+
+def build_profile(info: dict) -> str:
+    """Compose bio text from influencer information.
+
+    It stitches together organization, education and experience into a
+    multi-line string suitable for template rendering.
+    """
+    parts: List[str] = []
+    current = info.get("current_position")
+    if isinstance(current, dict):
+        org = current.get("organization")
+        if org:
+            parts.append(org)
+    edu = info.get("highest_education")
+    if isinstance(edu, dict):
+        school = edu.get("school")
+        dept = edu.get("department")
+        edu_line = " ".join(filter(None, [school, dept]))
+        if edu_line:
+            parts.append(edu_line)
+    exp = info.get("experience")
+    if isinstance(exp, list):
+        parts.extend(exp)
+    elif isinstance(exp, str):
+        parts.append(exp)
+    return "\n".join(parts)
+
+
+def build_people(program: dict, influencers: Iterable) -> Tuple[List[dict], List[dict]]:
+    """Return (chairs, speakers) lists enriched with bio information."""
+    infl_by_name: Dict[str, dict] = {p.get("name"): p for p in iter_dicts(influencers)}
+
+    chairs: List[dict] = []
+    speakers: List[dict] = []
+    for entry in program.get("speakers", []) or []:
+        name = entry.get("name")
+        info = infl_by_name.get(name, {}) or {}
+        enriched = {
+            "name": name,
+            "title": info.get("current_position", {}).get("title", "")
+            if isinstance(info.get("current_position"), dict)
+            else "",
+            "profile": build_profile(info),
+            "photo_url": info.get("photo_url", ""),
+        }
+        if entry.get("type") == "主持人":
+            chairs.append(enriched)
+        else:
+            speakers.append(enriched)
+    return chairs, speakers

--- a/scripts/actions/render_with_chrome.py
+++ b/scripts/actions/render_with_chrome.py
@@ -143,22 +143,9 @@ def build_schedule(event):
     return schedule
 
 # Build speaker and chair lists augmented from influencer data
-infl_by_name = {p.get("name"): p for p in influencer_list if isinstance(p, dict)}
-chairs = []
-speakers = []
-for speaker_entry in program_data.get("speakers", []) or []:
-    name = speaker_entry.get("name")
-    info = infl_by_name.get(name, {}) or {}
-    enriched = {
-        "name": name,
-        "title": info.get("current_position", {}).get("title", "") if isinstance(info.get("current_position"), dict) else "",
-        "profile": "\n".join(info.get("experience", [])) if isinstance(info.get("experience"), list) else info.get("experience", "") or "",
-        "photo_url": info.get("photo_url", ""),
-    }
-    if speaker_entry.get("type") == "主持人":
-        chairs.append(enriched)
-    else:
-        speakers.append(enriched)
+from scripts.actions.influencer import build_people
+
+chairs, speakers = build_people(program_data, influencer_list)
 
 # Use build_table (from schedule_table) as the main schedule generator.
 # If it fails, fall back to build_schedule(program_data).

--- a/tests/test_influencer_profiles.py
+++ b/tests/test_influencer_profiles.py
@@ -1,0 +1,39 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.actions.influencer import iter_dicts, build_profile, build_people
+
+DATA_DIR = Path('data/shared')
+
+
+def test_iter_dicts_flattens_nested_lists():
+    nested = [{'name': 'A'}, [{'name': 'B'}, {'name': 'C'}]]
+    names = {d['name'] for d in iter_dicts(nested)}
+    assert names == {'A', 'B', 'C'}
+
+
+def test_build_profile_includes_org_education_and_experience():
+    info = {
+        'current_position': {'organization': 'Org', 'title': 'T'},
+        'highest_education': {'school': 'S', 'department': 'D'},
+        'experience': ['E1', 'E2']
+    }
+    profile = build_profile(info)
+    assert 'Org' in profile
+    assert 'S D' in profile
+    assert 'E1' in profile and 'E2' in profile
+
+
+def test_build_people_matches_influencer_names():
+    programs = json.loads((DATA_DIR / 'program_data.json').read_text(encoding='utf-8'))
+    influencers = json.loads((DATA_DIR / 'influencer_data.json').read_text(encoding='utf-8'))
+    first_event = programs[0]
+    chairs, speakers = build_people(first_event, influencers)
+    by_name = {p['name']: p for p in chairs + speakers}
+    for name in ['林世嘉', '林奕汝', '中山功一', '官建村']:
+        assert by_name[name]['profile'], name


### PR DESCRIPTION
## Summary
- Ensure nested influencer data is flattened before building lookup so speaker bios display correctly
- Include organization, education, and experience when building each speaker bio
- Add unit tests for bio helpers to confirm profiles populate for all speakers

## Testing
- `pytest`
- `python -m py_compile scripts/actions/render_with_chrome.py scripts/actions/influencer.py`
- `pip install jinja2` *(failed: Could not find a version due to proxy)*
- `python scripts/actions/render_with_chrome.py` *(failed: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_68ad0eb94ca883318437480d7d3671a4