### PR TITLE
Separate profile sections in docx rendering

### DIFF
--- a/scripts/actions/influencer.py
+++ b/scripts/actions/influencer.py
@@ -42,12 +42,64 @@ def build_profile(info: dict) -> str:
     elif isinstance(exp, str):
         parts.append(exp)
 
-        exp = info.get("achievements")
-    if isinstance(exp, list):
-        parts.extend(exp)
-    elif isinstance(exp, str):
-        parts.append(exp)
+    # achievements may be stored separately; include them as part of profile
+    ach = info.get("achievements")
+    if isinstance(ach, list):
+        parts.extend(ach)
+    elif isinstance(ach, str):
+        parts.append(ach)
     return "\n".join(parts)
+
+
+def build_profile_sections(info: dict) -> Dict[str, List[str]]:
+    """Return structured profile sections with headings.
+
+    The sections are returned in an ordered dictionary mapping a Chinese
+    heading (e.g. ``"現職"``) to a list of lines. Only non-empty sections are
+    included.
+    """
+    sections: Dict[str, List[str]] = {}
+
+    # Current position
+    current = info.get("current_position")
+    if isinstance(current, dict):
+        org = current.get("organization")
+        title = current.get("title")
+        line = " ".join(filter(None, [org, title]))
+        if line:
+            sections["現職"] = [line]
+
+    # Education
+    edu = info.get("highest_education")
+    if isinstance(edu, dict):
+        school = edu.get("school")
+        dept = edu.get("department")
+        line = " ".join(filter(None, [school, dept]))
+        if line:
+            sections["學歷"] = [line]
+
+    # Experience
+    exp = info.get("experience")
+    if isinstance(exp, list) and exp:
+        sections["經歷"] = exp
+    elif isinstance(exp, str) and exp:
+        sections["經歷"] = [exp]
+
+    # Achievements
+    ach = info.get("achievements")
+    if isinstance(ach, list) and ach:
+        sections["成就"] = ach
+    elif isinstance(ach, str) and ach:
+        sections["成就"] = [ach]
+
+    # Specialties
+    spec = info.get("specialties")
+    if isinstance(spec, list) and spec:
+        sections["專長"] = spec
+    elif isinstance(spec, str) and spec:
+        sections["專長"] = [spec]
+
+    return sections
 
 
 def build_people(program: dict, influencers: Iterable) -> Tuple[List[dict], List[dict]]:
@@ -66,6 +118,7 @@ def build_people(program: dict, influencers: Iterable) -> Tuple[List[dict], List
             else "",
             "profile": build_profile(info),
             "photo_url": info.get("photo_url", ""),
+            "profile_sections": build_profile_sections(info),
         }
         if entry.get("type") == "主持人":
             chairs.append(enriched)

--- a/scripts/actions/render_to_docx.py
+++ b/scripts/actions/render_to_docx.py
@@ -270,18 +270,30 @@ def main() -> None:
             if title:
                 title_run = p.add_run(f" {title}")
                 set_run_font(title_run, NAME_PT)
-            prof = ch.get("profile")
-            if prof:
-                prof_p = doc.add_paragraph(prof)
-                for r in prof_p.runs:
-                    set_run_font(r, PROFILE_PT)
+
+            sections = ch.get("profile_sections") or {}
+            if sections:
+                for heading, lines in sections.items():
+                    head_p = doc.add_paragraph()
+                    head_run = head_p.add_run(heading)
+                    set_run_font(head_run, PROFILE_PT, bold=True)
+                    for line in lines:
+                        line_p = doc.add_paragraph(line, style="List Bullet")
+                        for r in line_p.runs:
+                            set_run_font(r, PROFILE_PT)
+            else:
+                prof = ch.get("profile")
+                if prof:
+                    prof_p = doc.add_paragraph(prof)
+                    for r in prof_p.runs:
+                        set_run_font(r, PROFILE_PT)
         doc.add_page_break()
 
     h4 = doc.add_heading("講者", level=1)
     h4.style = 'Heading 1'
     if speakers:
 
-        for sp in speakers:
+        for idx, sp in enumerate(speakers):
             doc.add_paragraph("講者")
             p = doc.add_paragraph()
             name_run = p.add_run(sp.get("name", ""))
@@ -290,11 +302,24 @@ def main() -> None:
             if title:
                 title_run = p.add_run(f" {title}")
                 set_run_font(title_run, NAME_PT)
-            prof = sp.get("profile")
-            if prof:
-                prof_p = doc.add_paragraph(prof)
-                for r in prof_p.runs:
-                    set_run_font(r, PROFILE_PT)
+
+            sections = sp.get("profile_sections") or {}
+            if sections:
+                for heading, lines in sections.items():
+                    head_p = doc.add_paragraph()
+                    head_run = head_p.add_run(heading)
+                    set_run_font(head_run, PROFILE_PT, bold=True)
+                    for line in lines:
+                        line_p = doc.add_paragraph(line, style="List Bullet")
+                        for r in line_p.runs:
+                            set_run_font(r, PROFILE_PT)
+            else:
+                prof = sp.get("profile")
+                if prof:
+                    prof_p = doc.add_paragraph(prof)
+                    for r in prof_p.runs:
+                        set_run_font(r, PROFILE_PT)
+
             if idx != len(speakers) - 1:
                 doc.add_page_break()
         doc.add_page_break()


### PR DESCRIPTION
## Summary
- Build structured profile sections for influencers (current position, education, experience, achievements, specialties)
- Display profile sections with headings and bullet points when generating docx

## Testing
- `pytest`
- `python scripts/actions/render_to_docx.py` *(fails: ModuleNotFoundError: No module named 'docx')*
- `pip install python-docx` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6b4427e4833191a69c0fbf37ede7