### PR TITLE
Refactor sign-in table rendering and add Excel entry point

### DIFF
--- a/scripts/actions/siginin_table_from_excel.py
+++ b/scripts/actions/siginin_table_from_excel.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+import pandas as pd
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.actions import format_date
+from scripts.actions.signin_table_render import (
+    SignInDocumentContext,
+    SignInRow,
+    render_signin_table,
+)
+from scripts.core.bootstrap import OUTPUT_DIR, initialize
+
+
+def _safe_filename_component(value: str) -> str:
+    translation = str.maketrans({ch: "_" for ch in '\\/:*?"<>|'})
+    cleaned = value.translate(translation)
+    return cleaned.strip() or "Program"
+
+
+def _detect_column(columns: Iterable[str], keywords: Iterable[str]) -> Optional[str]:
+    keyword_list = [k.strip().lower() for k in keywords]
+    for col in columns:
+        label = str(col or "").strip()
+        lower = label.lower()
+        for key in keyword_list:
+            if key and key in lower:
+                return label
+            if key and key in label:
+                return label
+    return None
+
+
+def _strip_value(val) -> str:
+    if val is None:
+        return ""
+    text = str(val)
+    return text.strip()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render speaker sign-in table from Excel")
+    parser.add_argument("excel", type=Path, help="Input Excel file path")
+    parser.add_argument("--sheet", help="Sheet name or index", default=0)
+    parser.add_argument("--plan-name", help="Plan name for the document", default=None)
+    parser.add_argument("--event-name", help="Event name for the document", default=None)
+    parser.add_argument("--date", help="Event date (YYYY-MM-DD)", default=None)
+    parser.add_argument("--out", type=Path, help="Output .docx path", default=None)
+    parser.add_argument("--topic-col", help="Explicit topic column name", default=None)
+    parser.add_argument("--name-col", help="Explicit name column name", default=None)
+    parser.add_argument("--title-col", help="Explicit title column name", default=None)
+    parser.add_argument("--organization-col", help="Explicit organization column name", default=None)
+    args = parser.parse_args()
+
+    initialize()
+
+    sheet = args.sheet
+    if isinstance(sheet, str) and sheet.isdigit():
+        sheet = int(sheet)
+
+    try:
+        df = pd.read_excel(args.excel, sheet_name=sheet)
+    except TypeError:
+        df = pd.read_excel(args.excel, sheet_name=sheet, engine="openpyxl")
+
+    df = df.fillna("")
+
+    columns = [str(c) for c in df.columns.tolist()]
+    topic_col = args.topic_col or _detect_column(columns, ["topic", "主題", "議題", "題目"])
+    name_col = args.name_col or _detect_column(columns, ["name", "姓名"])
+    title_col = args.title_col or _detect_column(columns, ["title", "職稱", "頭銜"])
+    org_col = args.organization_col or _detect_column(
+        columns,
+        ["organization", "company", "單位", "服務單位", "機構", "組織", "affiliation", "部門"],
+    )
+
+    if not name_col:
+        raise SystemExit("未能自動辨識姓名欄位，請使用 --name-col 指定。")
+
+    rows: list[SignInRow] = []
+    for _, row in df.iterrows():
+        name_val = _strip_value(row.get(name_col))
+        if not name_val:
+            continue
+        topic_val = _strip_value(row.get(topic_col)) if topic_col else ""
+        title_val = _strip_value(row.get(title_col)) if title_col else ""
+        org_val = _strip_value(row.get(org_col)) if org_col else ""
+        rows.append(
+            SignInRow(
+                topic=topic_val,
+                name=name_val,
+                title=title_val,
+                organization=org_val,
+            )
+        )
+
+    if not rows:
+        raise SystemExit("Excel 檔案中找不到任何有效的講者資料。")
+
+    plan_name = args.plan_name or args.event_name or args.excel.stem
+    event_name = args.event_name or plan_name
+    date_display = format_date(args.date, sep="/") if args.date else None
+
+    safe_event_name = _safe_filename_component(event_name)
+    out_path = args.out or (OUTPUT_DIR / f"講師簽到表_{safe_event_name}.docx")
+
+    context = SignInDocumentContext(
+        plan_name=plan_name,
+        event_name=event_name,
+        date_display=date_display,
+        subtitle="講員簽到單",
+    )
+
+    result = render_signin_table(context, rows, out_path)
+    print(
+        f"Saved sign-in sheet to {result.output_path} "
+        f"(page_width_cm={result.page_width_cm:.2f}, available_cm={result.available_width_cm:.2f}, "
+        f"cols_cm={list(result.columns_cm)})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/actions/siginin_table_from_json.py
+++ b/scripts/actions/siginin_table_from_json.py
@@ -2,42 +2,24 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Any, Dict, List
-
-from docx import Document
-from docx.enum.table import WD_TABLE_ALIGNMENT, WD_ROW_HEIGHT_RULE
-from docx.enum.text import WD_ALIGN_PARAGRAPH
-from docx.oxml import OxmlElement
-from docx.oxml.ns import qn
-from docx.shared import Pt
-import sys
-# 若要把單元格直向置中（通常與固定高度一起用）
-from docx.enum.table import WD_ALIGN_VERTICAL
-from __init__ import format_date
 
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
-# Project helpers
-from scripts.core.bootstrap import DATA_DIR, OUTPUT_DIR, initialize
-from scripts.actions.influencer import build_people
-from docx.shared import Cm
-from docx.shared import Pt, RGBColor
 
-# -----------------------
-# 可修改的程式碼參數（直接在程式中改）
-TITLE_PT = 16                 # 全域字型大小 (pt)
-FONT_PT = 14                 # 全域字型大小 (pt)
-LEFT_RIGHT_MARGIN_CM = 1.5   # 左右邊界 (cm)
-COL0_FIXED_CM = 8.0         # 第一欄 (Topic) 固定寬度 (cm)
-COL1_FIXED_CM = 8.0          # 第二欄 (Speaker) 固定寬度 (cm)
-# 第三欄由 available - (col0+col1) 決定
-HDR_HEIGHT_CM = 0.9          # 表頭列高 (cm)
-DATA_ROW_HEIGHT_CM = 3.5    # 每筆資料列高 (cm)
-# DATA_ROWS_PER_PAGE = 20     # 若要每頁固定列數，可在 future 使用
-# -----------------------
+from scripts.actions import format_date
+from scripts.actions.influencer import build_people
+from scripts.actions.signin_table_render import (
+    SignInDocumentContext,
+    SignInRow,
+    render_signin_table,
+)
+from scripts.core.bootstrap import DATA_DIR, OUTPUT_DIR, initialize
+
 
 def load_program(program_id: int | None) -> Dict[str, Any]:
     data_file = DATA_DIR / "shared" / "program_data.json"
@@ -55,30 +37,6 @@ def load_program(program_id: int | None) -> Dict[str, Any]:
         return programs_raw
     return {}
 
-def set_run_font(run, size_pt: int, bold: bool = False) -> None:
-    run.font.name = "Times New Roman"
-    run._element.rPr.rFonts.set(qn("w:eastAsia"), "標楷體")
-    run.font.size = Pt(size_pt)
-    run.bold = bold
-
-def set_table_cell_margins(table, left_cm: float = 0.1, right_cm: float = 0.1, top_pt: int = 0, bottom_pt: int = 0):
-    tbl = table._tbl
-    tblPr = tbl.tblPr
-    tcMar = tblPr.find(qn("w:tblCellMar"))
-    if tcMar is None:
-        tcMar = OxmlElement("w:tblCellMar")
-        tblPr.append(tcMar)
-    def _set_node(name: str, cm_val: float, parent: OxmlElement):
-        node = parent.find(qn(f"w:{name}"))
-        if node is None:
-            node = OxmlElement(f"w:{name}")
-            parent.append(node)
-        node.set(qn("w:w"), str(int(cm_val * 567)))  # dxa
-        node.set(qn("w:type"), "dxa")
-    _set_node("left", left_cm, tcMar)
-    _set_node("right", right_cm, tcMar)
-    _set_node("top", (top_pt / 72.0) * 2.54 if top_pt else 0, tcMar)
-    _set_node("bottom", (bottom_pt / 72.0) * 2.54 if bottom_pt else 0, tcMar)
 
 def _get_first_nonempty(sp: dict, keys: List[str]) -> str:
     for k in keys:
@@ -96,113 +54,15 @@ def _get_first_nonempty(sp: dict, keys: List[str]) -> str:
                     return v2.strip()
     return ""
 
-def _set_table_total_width(table, total_cm: float):
-    tbl = table._tbl
-    tblPr = tbl.tblPr
-    existing = tblPr.find(qn("w:tblW"))
-    if existing is not None:
-        tblPr.remove(existing)
-    tblW = OxmlElement("w:tblW")
-    tblW.set(qn("w:w"), str(int(total_cm * 567)))
-    tblW.set(qn("w:type"), "dxa")
-    tblPr.append(tblW)
 
-def safe_set_row_height(row, height_cm: float, preferred_rule: str = "EXACT"):
-    """設定 row.height，並安全嘗試設定 height_rule（各版本相容）。"""
-    row.height = Cm(height_cm)
-    rule_value = None
-    if hasattr(WD_ROW_HEIGHT_RULE, preferred_rule):
-        rule_value = getattr(WD_ROW_HEIGHT_RULE, preferred_rule)
-    else:
-        for alt in ("EXACT", "AT_LEAST", "AUTO"):
-            if hasattr(WD_ROW_HEIGHT_RULE, alt):
-                rule_value = getattr(WD_ROW_HEIGHT_RULE, alt)
-                break
-    if rule_value is not None:
-        try:
-            row.height_rule = rule_value
-        except Exception:
-            pass
+def _safe_filename_component(value: str) -> str:
+    translation = str.maketrans({ch: "_" for ch in '\\/:*?"<>|'})
+    cleaned = value.translate(translation)
+    return cleaned.strip() or "Program"
 
-
-
-def set_row_height_exact(row, height_cm: float):
-    """
-    對單一 row 設定固定高度 (cm)。如果 environment 支援 EXACT，使用 EXACT，
-    否則退回 AT_LEAST / AUTO（安全相容）。
-    """
-    # 設高度（cm）
-    row.height = Cm(height_cm)
-
-    # 嘗試使用 EXACT，沒有再退回 AT_LEAST / AUTO
-    rule_value = None
-    if hasattr(WD_ROW_HEIGHT_RULE, "EXACT"):
-        rule_value = WD_ROW_HEIGHT_RULE.EXACT
-    elif hasattr(WD_ROW_HEIGHT_RULE, "AT_LEAST"):
-        rule_value = WD_ROW_HEIGHT_RULE.AT_LEAST
-    elif hasattr(WD_ROW_HEIGHT_RULE, "AUTO"):
-        rule_value = WD_ROW_HEIGHT_RULE.AUTO
-
-    if rule_value is not None:
-        try:
-            row.height_rule = rule_value
-        except Exception:
-            # 某些 python-docx 版本可能不允許直接指派，忽略錯誤即可
-            pass
-
-def set_table_rows_height(table, height_cm: float):
-    """對 table 裡所有現存的 row 設定固定高度（包含 header 與資料列）"""
-    for r in table.rows:
-        set_row_height_exact(r, height_cm)
-
-
-def set_cell_vertical_center(cell):
-    try:
-        cell.vertical_alignment = WD_ALIGN_VERTICAL.CENTER
-    except Exception:
-        # 忽略不支援情況
-        pass
-def set_cell_background(cell, color_hex: str):
-    """
-    對單一 cell 設定背景色（hex，例如 '#BFBFBF' 或 'BFBFBF'）。
-    """
-    # normalize
-    color = color_hex.lstrip("#")
-    # access or create tcPr
-    tc = cell._tc
-    tcPr = tc.find(qn("w:tcPr"))
-    if tcPr is None:
-        tcPr = OxmlElement("w:tcPr")
-        tc.append(tcPr)
-    # remove existing shd if any
-    existing = tcPr.find(qn("w:shd"))
-    if existing is not None:
-        tcPr.remove(existing)
-    # create shading element
-    shd = OxmlElement("w:shd")
-    # w:val can be 'clear' or 'nil' etc; set fill to color hex
-    shd.set(qn("w:val"), "clear")
-    shd.set(qn("w:color"), "auto")
-    shd.set(qn("w:fill"), color.upper())
-    tcPr.append(shd)
-
-def set_run_color_black(run):
-    """簡單把 run 的文字顏色設成黑色，避免淺底看不清楚。"""
-    try:
-        run.font.color.rgb = RGBColor(0x00, 0x00, 0x00)
-    except Exception:
-        pass
-def set_repeat_table_header(row) -> None:
-    """讓指定的 row 在跨頁時重複顯示為表頭"""
-    tr = row._tr
-    trPr = tr.get_or_add_trPr()
-    if trPr.find(qn("w:tblHeader")) is None:
-        tbl_header = OxmlElement("w:tblHeader")
-        tbl_header.set(qn("w:val"), "true")
-        trPr.append(tbl_header)
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Render program to docx")
+    parser = argparse.ArgumentParser(description="Render program speaker sign-in table")
     parser.add_argument("--program-id", type=int, default=None, help="Program id to render")
     parser.add_argument("--out", type=Path, default=None, help="Output .docx path")
     args = parser.parse_args()
@@ -210,21 +70,13 @@ def main() -> None:
     initialize()
     program = load_program(args.program_id)
 
-    # load influencer & build people
     infl_file = DATA_DIR / "shared" / "influencer_data.json"
     try:
         influencers = json.loads(infl_file.read_text(encoding="utf-8"))
     except OSError:
         influencers = []
-    chairs, speakers = build_people(program, influencers)
+    _, speakers = build_people(program, influencers)
 
-    # # program topic map
-    # program_speakers = program.get("speakers", []) or []
-    # program_topic_map: Dict[str, str] = {
-    #     (entry.get("name") or "").strip(): (entry.get("topic") or "").strip()
-    #     for entry in program_speakers
-    # }
-    # Collect program speaker entries of type "講者" in declared order
     program_speaker_entries = [
         entry
         for entry in (program.get("speakers") or [])
@@ -232,256 +84,57 @@ def main() -> None:
     ]
     program_speaker_entries.sort(key=lambda e: e.get("no", 0))
 
-    planName = program.get("planName")
-    event_name = (program.get("eventNames") or ["Program"])[0]
-    date = program.get("date")
+    plan_name = (program.get("planName") or "").strip()
+    event_names = program.get("eventNames") or []
+    event_name = (event_names[0] if event_names else "Program") or "Program"
+    date = (program.get("date") or "").strip()
+    slash_date = format_date(date, sep="/") if date else None
 
-    out_path = args.out or (OUTPUT_DIR / f"講師簽到表_{program.get('eventNames')[0]}.docx")
+    rows: List[SignInRow] = []
+    for idx, sp in enumerate(speakers):
+        name_val = (sp.get("name") or "").strip()
+        topic_val = ""
+        if idx < len(program_speaker_entries):
+            topic_val = (program_speaker_entries[idx].get("topic") or "").strip()
+        title_val = _get_first_nonempty(sp, ["title", "position", "role"])
+        org_val = _get_first_nonempty(
+            sp,
+            [
+                "organization",
+                "company",
+                "affiliation",
+                "department",
+                "dept",
+                "unit",
+                "employer",
+            ],
+        )
+        rows.append(
+            SignInRow(
+                topic=topic_val,
+                name=name_val,
+                title=title_val,
+                organization=org_val,
+            )
+        )
 
-    # 使用程式內參數 FONT_PT
-    font_pt = int(FONT_PT)
+    safe_event_name = _safe_filename_component(event_name)
+    out_path = args.out or (OUTPUT_DIR / f"講師簽到表_{safe_event_name}.docx")
 
-    doc = Document()
-    normal_style = doc.styles["Normal"]
-    normal_font = normal_style.font
-    normal_font.name = "Times New Roman"
-    normal_style._element.rPr.rFonts.set(qn("w:eastAsia"), "標楷體")
-    normal_font.size = Pt(font_pt)
+    context = SignInDocumentContext(
+        plan_name=plan_name or event_name,
+        event_name=event_name,
+        date_display=slash_date,
+        subtitle="講員簽到單",
+    )
 
-    # Title
-    p_t = doc.add_paragraph()
-    p_t.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    p_t_run = p_t.add_run(str(planName))
-    set_run_font(p_t_run, TITLE_PT, bold=True)
+    result = render_signin_table(context, rows, out_path)
+    print(
+        f"Saved sign-in sheet to {result.output_path} "
+        f"(page_width_cm={result.page_width_cm:.2f}, available_cm={result.available_width_cm:.2f}, "
+        f"cols_cm={list(result.columns_cm)})"
+    )
 
-    p_e = doc.add_paragraph()
-    p_e.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    p_e_run = p_e.add_run(str(event_name))
-    set_run_font(p_e_run, TITLE_PT, bold=True)
-
-    p_e = doc.add_paragraph()
-    slash_date =format_date(date, sep="/")
-    p_e.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    p_e_run = p_e.add_run("("+str(slash_date)+")")
-    set_run_font(p_e_run, TITLE_PT, bold=True)
-
-    p_e = doc.add_paragraph()
-    p_e.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    p_e_run = p_e.add_run("講員簽到單")
-    set_run_font(p_e_run, TITLE_PT, bold=True)
-
-    # 固定左右邊界（cm）
-    doc.sections[0].left_margin = Cm(LEFT_RIGHT_MARGIN_CM)
-    doc.sections[0].right_margin = Cm(LEFT_RIGHT_MARGIN_CM)
-
-    # 建表（寫死欄寬但有保護機制）
-    signin_table = doc.add_table(rows=1, cols=3, style="Table Grid")
-    signin_table.autofit = False
-    signin_table.alignment = WD_TABLE_ALIGNMENT.CENTER
-    try:
-        signin_table.left_indent = Cm(0)
-    except Exception:
-        pass
-
-    # 計算 page 與 available width（cm）
-    page_width_cm = float(doc.sections[0].page_width) / float(Cm(1))
-    available_cm = page_width_cm - (LEFT_RIGHT_MARGIN_CM * 2)
-
-    # 先計算第三欄為剩餘空間
-    col0 = float(COL0_FIXED_CM)
-    col1 = float(COL1_FIXED_CM)
-    col2 = available_cm - (col0 + col1)
-
-    # 若總寬超過 available，等比例縮放三欄（確保不超出）
-    total_req = col0 + col1 + (col2 if col2 > 0 else 0)
-    if total_req > available_cm:
-        scale = available_cm / total_req
-        col0 *= scale
-        col1 *= scale
-        col2 = max(1.5, available_cm - (col0 + col1))
-
-    # 最後保護（col2 至少 1.5 cm）
-    if col2 < 1.5:
-        col2 = 1.5
-        if col0 + col1 + col2 > available_cm:
-            remain = max(0, available_cm - col2)
-            if col0 + col1 > 0:
-                ratio = col0 / (col0 + col1)
-            else:
-                ratio = 0.6
-            col0 = remain * ratio
-            col1 = remain - col0
-
-    # 設定欄寬與 table 寬
-    signin_table.columns[0].width = Cm(col0)
-    signin_table.columns[1].width = Cm(col1)
-    signin_table.columns[2].width = Cm(col2)
-    _set_table_total_width(signin_table, col0 + col1 + col2)
-
-    # 縮小 cell padding
-    set_table_cell_margins(signin_table, left_cm=0.12, right_cm=0.12)
-
-
-
-
-
-    # 表頭
-    hdr = signin_table.rows[0]
-    safe_set_row_height(hdr, HDR_HEIGHT_CM)
-
-    set_repeat_table_header(hdr)
-
-
-    # 設 header 高度為 0.9 cm
-    set_row_height_exact(signin_table.rows[0], 0.9)
-    hdr_cells = hdr.cells
-    p = hdr_cells[0].paragraphs[0]
-    # p.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    run = p.add_run("主題 Topic")
-    set_run_font(run, font_pt, bold=True)
-
-    p = hdr_cells[1].paragraphs[0]
-    # p.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    run = p.add_run("姓名 Name")
-    set_run_font(run, font_pt, bold=True)
-
-    p = hdr_cells[2].paragraphs[0]
-    # p.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    run = p.add_run("簽到 Sign-in")
-    set_run_font(run, font_pt, bold=True)
-
-
-    for cell in hdr.cells:
-        # set_table_cell_margins(cell, left_cm=0.0, right_cm=0.0, top_cm=0.0, bottom_cm=0.0)
-        cell.vertical_alignment = WD_ALIGN_VERTICAL.CENTER
-        # 並把 paragraph 設水平置中
-        p = cell.paragraphs[0]
-        p.alignment = WD_ALIGN_PARAGRAPH.CENTER
-        set_cell_background(cell, "#BFBFBF")
-    # 資料列（每位講者一列）
-    # 在檔案開頭確保已 import：
-# from docx.enum.table import WD_ALIGN_VERTICAL
-
-    # 替換原本的 if speakers: 迴圈
-    if speakers:
-        # for sp in speakers:
-        for idx, sp in enumerate(speakers):
-            # 新增一列並設定固定列高（使用你已有的 helper）
-            row = signin_table.add_row()
-            try:
-                set_row_height_exact(row, DATA_ROW_HEIGHT_CM)  # 若你定義了 exact helper
-            except NameError:
-                safe_set_row_height(row, DATA_ROW_HEIGHT_CM)
-
-            row_cells = row.cells
-            name_val = (sp.get("name") or "").strip()
-            # topic_val = program_topic_map.get(name_val, "") or ""
-            topic_val = ""
-            if idx < len(program_speaker_entries):
-                topic_val = (program_speaker_entries[idx].get("topic") or "").strip()
-
-            # ---------- 第一欄：Topic（覆寫第一個 paragraph） ----------
-            c0 = row_cells[0]
-            p0 = c0.paragraphs[0] if c0.paragraphs else c0.add_paragraph()
-            # 清除段內 runs（保險）
-            for r in list(p0.runs):
-                try:
-                    r._element.getparent().remove(r._element)
-                except Exception:
-                    pass
-            # 寫入 topic（若空放 NBSP）
-            p0.add_run(topic_val or "\u00A0")
-            p0.alignment = WD_ALIGN_PARAGRAPH.LEFT
-            # 取消段落上下間距（可選）
-            try:
-                p0.paragraph_format.space_before = Pt(0)
-                p0.paragraph_format.space_after = Pt(0)
-            except Exception:
-                pass
-            # 垂直置中 cell
-            try:
-                c0.vertical_alignment = WD_ALIGN_VERTICAL.CENTER
-            except Exception:
-                pass
-
-            # ---------- 第二欄：Speaker（姓名+職稱 第一行，組織 第二行） ----------
-            title_val = _get_first_nonempty(sp, ["title", "position", "role"]) or ""
-            org_val = _get_first_nonempty(sp, ["organization", "company", "affiliation", "department", "dept", "unit", "employer"]) or ""
-
-            c1 = row_cells[1]
-            p1 = c1.paragraphs[0] if c1.paragraphs else c1.add_paragraph()
-            # 清除原 runs
-            for r in list(p1.runs):
-                try:
-                    r._element.getparent().remove(r._element)
-                except Exception:
-                    pass
-            # 姓名（粗體）
-            r_name = p1.add_run(name_val or "\u00A0")
-            set_run_font(r_name, font_pt, bold=True)
-            # 職稱（同段，不粗體）
-            if title_val:
-                r_title = p1.add_run(" " + title_val)
-                set_run_font(r_title, font_pt, bold=False)
-            p1.alignment = WD_ALIGN_PARAGRAPH.LEFT
-            try:
-                p1.paragraph_format.space_before = Pt(0)
-                p1.paragraph_format.space_after = Pt(0)
-            except Exception:
-                pass
-
-            # 組織另起一行
-            if org_val:
-                org_p = c1.add_paragraph()
-                # 清空 runs（通常新段落沒 runs）
-                org_p.text = org_val
-                if org_p.runs:
-                    set_run_font(org_p.runs[0], font_pt, bold=False)
-                try:
-                    org_p.paragraph_format.space_before = Pt(0)
-                    org_p.paragraph_format.space_after = Pt(0)
-                except Exception:
-                    pass
-
-            # 垂直置中第二欄
-            try:
-                c1.vertical_alignment = WD_ALIGN_VERTICAL.CENTER
-            except Exception:
-                pass
-
-            # ---------- 第三欄：簽到欄（NBSP 占位） ----------
-            c2 = row_cells[2]
-            p2 = c2.paragraphs[0] if c2.paragraphs else c2.add_paragraph()
-            # 清除 runs 並放 NBSP
-            for r in list(p2.runs):
-                try:
-                    r._element.getparent().remove(r._element)
-                except Exception:
-                    pass
-            r2 = p2.add_run("\u00A0")
-            try:
-                r2.font.size = Pt(font_pt)
-            except Exception:
-                pass
-            p2.alignment = WD_ALIGN_PARAGRAPH.LEFT
-            try:
-                p2.paragraph_format.space_before = Pt(0)
-                p2.paragraph_format.space_after = Pt(0)
-            except Exception:
-                pass
-            try:
-                c2.vertical_alignment = WD_ALIGN_VERTICAL.CENTER
-            except Exception:
-                pass
-
-    p_e = doc.add_paragraph()
-    p_e.alignment = WD_ALIGN_PARAGRAPH.RIGHT
-    p_e_run = p_e.add_run(slash_date)
-    set_run_font(p_e_run, FONT_PT, bold=False)
-
-    # 儲存
-    doc.save(out_path)
-    print(f"Saved sign-in sheet to {out_path} (page_width_cm={page_width_cm:.2f}, available_cm={available_cm:.2f}, cols_cm={[col0, col1, col2]})")
 
 if __name__ == "__main__":
     main()

--- a/scripts/actions/signin_table_render.py
+++ b/scripts/actions/signin_table_render.py
@@ -1,0 +1,396 @@
+"""Utilities for rendering speaker sign-in tables to Word documents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence, Tuple
+
+from docx import Document
+from docx.enum.table import WD_ALIGN_VERTICAL, WD_ROW_HEIGHT_RULE, WD_TABLE_ALIGNMENT
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+from docx.shared import Cm, Pt, RGBColor
+
+
+# Default layout constants (cm / pt)
+TITLE_PT = 16
+FONT_PT = 14
+LEFT_RIGHT_MARGIN_CM = 1.5
+COL0_FIXED_CM = 8.0
+COL1_FIXED_CM = 8.0
+HDR_HEIGHT_CM = 0.9
+DATA_ROW_HEIGHT_CM = 3.5
+
+
+@dataclass
+class SignInRow:
+    """Single row entry for the sign-in table."""
+
+    topic: str = ""
+    name: str = ""
+    title: str = ""
+    organization: str = ""
+
+
+@dataclass
+class SignInDocumentContext:
+    """Document level metadata used when rendering the sign-in sheet."""
+
+    plan_name: str = ""
+    event_name: str = ""
+    date_display: str | None = None
+    subtitle: str = "講員簽到單"
+
+
+@dataclass
+class SignInRenderResult:
+    """Return information after rendering a sign-in sheet."""
+
+    output_path: Path
+    page_width_cm: float
+    available_width_cm: float
+    columns_cm: Tuple[float, float, float]
+
+
+def _set_run_font(run, size_pt: int, bold: bool = False) -> None:
+    run.font.name = "Times New Roman"
+    run._element.rPr.rFonts.set(qn("w:eastAsia"), "標楷體")
+    run.font.size = Pt(size_pt)
+    run.bold = bold
+
+
+def _set_table_cell_margins(
+    table, left_cm: float = 0.1, right_cm: float = 0.1, top_pt: int = 0, bottom_pt: int = 0
+):
+    tbl = table._tbl
+    tblPr = tbl.tblPr
+    tcMar = tblPr.find(qn("w:tblCellMar"))
+    if tcMar is None:
+        tcMar = OxmlElement("w:tblCellMar")
+        tblPr.append(tcMar)
+
+    def _set_node(name: str, cm_val: float, parent: OxmlElement):
+        node = parent.find(qn(f"w:{name}"))
+        if node is None:
+            node = OxmlElement(f"w:{name}")
+            parent.append(node)
+        node.set(qn("w:w"), str(int(cm_val * 567)))
+        node.set(qn("w:type"), "dxa")
+
+    _set_node("left", left_cm, tcMar)
+    _set_node("right", right_cm, tcMar)
+    _set_node("top", (top_pt / 72.0) * 2.54 if top_pt else 0, tcMar)
+    _set_node("bottom", (bottom_pt / 72.0) * 2.54 if bottom_pt else 0, tcMar)
+
+
+def _set_table_total_width(table, total_cm: float):
+    tbl = table._tbl
+    tblPr = tbl.tblPr
+    existing = tblPr.find(qn("w:tblW"))
+    if existing is not None:
+        tblPr.remove(existing)
+    tblW = OxmlElement("w:tblW")
+    tblW.set(qn("w:w"), str(int(total_cm * 567)))
+    tblW.set(qn("w:type"), "dxa")
+    tblPr.append(tblW)
+
+
+def _safe_set_row_height(row, height_cm: float, preferred_rule: str = "EXACT"):
+    row.height = Cm(height_cm)
+    rule_value = None
+    if hasattr(WD_ROW_HEIGHT_RULE, preferred_rule):
+        rule_value = getattr(WD_ROW_HEIGHT_RULE, preferred_rule)
+    else:
+        for alt in ("EXACT", "AT_LEAST", "AUTO"):
+            if hasattr(WD_ROW_HEIGHT_RULE, alt):
+                rule_value = getattr(WD_ROW_HEIGHT_RULE, alt)
+                break
+    if rule_value is not None:
+        try:
+            row.height_rule = rule_value
+        except Exception:
+            pass
+
+
+def _set_row_height_exact(row, height_cm: float):
+    row.height = Cm(height_cm)
+    rule_value = None
+    if hasattr(WD_ROW_HEIGHT_RULE, "EXACT"):
+        rule_value = WD_ROW_HEIGHT_RULE.EXACT
+    elif hasattr(WD_ROW_HEIGHT_RULE, "AT_LEAST"):
+        rule_value = WD_ROW_HEIGHT_RULE.AT_LEAST
+    elif hasattr(WD_ROW_HEIGHT_RULE, "AUTO"):
+        rule_value = WD_ROW_HEIGHT_RULE.AUTO
+
+    if rule_value is not None:
+        try:
+            row.height_rule = rule_value
+        except Exception:
+            pass
+
+
+def _set_table_rows_height(table, height_cm: float):
+    for r in table.rows:
+        _set_row_height_exact(r, height_cm)
+
+
+def _set_cell_vertical_center(cell):
+    try:
+        cell.vertical_alignment = WD_ALIGN_VERTICAL.CENTER
+    except Exception:
+        pass
+
+
+def _set_cell_background(cell, color_hex: str):
+    color = color_hex.lstrip("#")
+    tc = cell._tc
+    tcPr = tc.find(qn("w:tcPr"))
+    if tcPr is None:
+        tcPr = OxmlElement("w:tcPr")
+        tc.append(tcPr)
+    existing = tcPr.find(qn("w:shd"))
+    if existing is not None:
+        tcPr.remove(existing)
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), "clear")
+    shd.set(qn("w:color"), "auto")
+    shd.set(qn("w:fill"), color.upper())
+    tcPr.append(shd)
+
+
+def _set_run_color_black(run):
+    try:
+        run.font.color.rgb = RGBColor(0x00, 0x00, 0x00)
+    except Exception:
+        pass
+
+
+def _set_repeat_table_header(row) -> None:
+    tr = row._tr
+    trPr = tr.get_or_add_trPr()
+    if trPr.find(qn("w:tblHeader")) is None:
+        tbl_header = OxmlElement("w:tblHeader")
+        tbl_header.set(qn("w:val"), "true")
+        trPr.append(tbl_header)
+
+
+def _sanitize_text(value: str | None) -> str:
+    return (value or "").strip()
+
+
+def render_signin_table(
+    context: SignInDocumentContext,
+    speakers: Sequence[SignInRow],
+    output_path: Path | str,
+    *,
+    title_pt: int = TITLE_PT,
+    font_pt: int = FONT_PT,
+    left_right_margin_cm: float = LEFT_RIGHT_MARGIN_CM,
+    col0_fixed_cm: float = COL0_FIXED_CM,
+    col1_fixed_cm: float = COL1_FIXED_CM,
+    data_row_height_cm: float = DATA_ROW_HEIGHT_CM,
+    header_height_cm: float = HDR_HEIGHT_CM,
+) -> SignInRenderResult:
+    """Render a sign-in table document and save it to ``output_path``."""
+
+    rows: list[SignInRow] = [row for row in speakers if any(_sanitize_text(getattr(row, f)) for f in ("name", "topic", "title", "organization"))]
+    out_path = Path(output_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    doc = Document()
+    normal_style = doc.styles["Normal"]
+    normal_font = normal_style.font
+    normal_font.name = "Times New Roman"
+    normal_style._element.rPr.rFonts.set(qn("w:eastAsia"), "標楷體")
+    normal_font.size = Pt(font_pt)
+
+    if context.plan_name:
+        p_plan = doc.add_paragraph()
+        p_plan.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = p_plan.add_run(context.plan_name)
+        _set_run_font(run, title_pt, bold=True)
+
+    if context.event_name:
+        p_event = doc.add_paragraph()
+        p_event.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = p_event.add_run(context.event_name)
+        _set_run_font(run, title_pt, bold=True)
+
+    if context.date_display:
+        p_date = doc.add_paragraph()
+        p_date.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = p_date.add_run(f"({context.date_display})")
+        _set_run_font(run, title_pt, bold=True)
+
+    if context.subtitle:
+        p_sub = doc.add_paragraph()
+        p_sub.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = p_sub.add_run(context.subtitle)
+        _set_run_font(run, title_pt, bold=True)
+
+    if doc.sections:
+        doc.sections[0].left_margin = Cm(left_right_margin_cm)
+        doc.sections[0].right_margin = Cm(left_right_margin_cm)
+
+    signin_table = doc.add_table(rows=1, cols=3, style="Table Grid")
+    signin_table.autofit = False
+    signin_table.alignment = WD_TABLE_ALIGNMENT.CENTER
+    try:
+        signin_table.left_indent = Cm(0)
+    except Exception:
+        pass
+
+    page_width_cm = float(doc.sections[0].page_width) / float(Cm(1)) if doc.sections else 0.0
+    available_cm = page_width_cm - (left_right_margin_cm * 2)
+
+    col0 = float(col0_fixed_cm)
+    col1 = float(col1_fixed_cm)
+    col2 = available_cm - (col0 + col1)
+
+    total_req = col0 + col1 + (col2 if col2 > 0 else 0)
+    if available_cm > 0 and total_req > available_cm:
+        scale = available_cm / total_req
+        col0 *= scale
+        col1 *= scale
+        col2 = max(1.5, available_cm - (col0 + col1))
+
+    if col2 < 1.5:
+        col2 = 1.5
+        if col0 + col1 + col2 > available_cm and available_cm > 0:
+            remain = max(0, available_cm - col2)
+            ratio = col0 / (col0 + col1) if (col0 + col1) else 0.6
+            col0 = remain * ratio
+            col1 = remain - col0
+
+    signin_table.columns[0].width = Cm(col0)
+    signin_table.columns[1].width = Cm(col1)
+    signin_table.columns[2].width = Cm(col2)
+    _set_table_total_width(signin_table, col0 + col1 + col2)
+    _set_table_cell_margins(signin_table, left_cm=0.12, right_cm=0.12)
+
+    hdr = signin_table.rows[0]
+    _safe_set_row_height(hdr, header_height_cm)
+    _set_repeat_table_header(hdr)
+    _set_row_height_exact(signin_table.rows[0], header_height_cm)
+
+    hdr_cells = hdr.cells
+    headers = ["主題 Topic", "姓名 Name", "簽到 Sign-in"]
+    for idx, text in enumerate(headers):
+        cell = hdr_cells[idx]
+        paragraph = cell.paragraphs[0]
+        run = paragraph.add_run(text)
+        _set_run_font(run, font_pt, bold=True)
+        paragraph.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        _set_cell_vertical_center(cell)
+        _set_cell_background(cell, "#BFBFBF")
+
+    for entry in rows:
+        row = signin_table.add_row()
+        try:
+            _set_row_height_exact(row, data_row_height_cm)
+        except NameError:
+            _safe_set_row_height(row, data_row_height_cm)
+
+        row_cells = row.cells
+        topic_val = _sanitize_text(entry.topic) or "\u00A0"
+        c0 = row_cells[0]
+        p0 = c0.paragraphs[0] if c0.paragraphs else c0.add_paragraph()
+        for r in list(p0.runs):
+            try:
+                r._element.getparent().remove(r._element)
+            except Exception:
+                pass
+        p0.add_run(topic_val)
+        p0.alignment = WD_ALIGN_PARAGRAPH.LEFT
+        try:
+            p0.paragraph_format.space_before = Pt(0)
+            p0.paragraph_format.space_after = Pt(0)
+        except Exception:
+            pass
+        _set_cell_vertical_center(c0)
+
+        name_val = _sanitize_text(entry.name) or "\u00A0"
+        title_val = _sanitize_text(entry.title)
+        org_val = _sanitize_text(entry.organization)
+
+        c1 = row_cells[1]
+        p1 = c1.paragraphs[0] if c1.paragraphs else c1.add_paragraph()
+        for r in list(p1.runs):
+            try:
+                r._element.getparent().remove(r._element)
+            except Exception:
+                pass
+        r_name = p1.add_run(name_val)
+        _set_run_font(r_name, font_pt, bold=True)
+        if title_val:
+            r_title = p1.add_run(f" {title_val}")
+            _set_run_font(r_title, font_pt, bold=False)
+        p1.alignment = WD_ALIGN_PARAGRAPH.LEFT
+        try:
+            p1.paragraph_format.space_before = Pt(0)
+            p1.paragraph_format.space_after = Pt(0)
+        except Exception:
+            pass
+
+        if org_val:
+            org_p = c1.add_paragraph()
+            org_p.text = org_val
+            if org_p.runs:
+                _set_run_font(org_p.runs[0], font_pt, bold=False)
+            try:
+                org_p.paragraph_format.space_before = Pt(0)
+                org_p.paragraph_format.space_after = Pt(0)
+            except Exception:
+                pass
+        _set_cell_vertical_center(c1)
+
+        c2 = row_cells[2]
+        p2 = c2.paragraphs[0] if c2.paragraphs else c2.add_paragraph()
+        for r in list(p2.runs):
+            try:
+                r._element.getparent().remove(r._element)
+            except Exception:
+                pass
+        r2 = p2.add_run("\u00A0")
+        try:
+            r2.font.size = Pt(font_pt)
+        except Exception:
+            pass
+        p2.alignment = WD_ALIGN_PARAGRAPH.LEFT
+        try:
+            p2.paragraph_format.space_before = Pt(0)
+            p2.paragraph_format.space_after = Pt(0)
+        except Exception:
+            pass
+        _set_cell_vertical_center(c2)
+
+    if context.date_display:
+        footer = doc.add_paragraph()
+        footer.alignment = WD_ALIGN_PARAGRAPH.RIGHT
+        run = footer.add_run(context.date_display)
+        _set_run_font(run, font_pt, bold=False)
+
+    doc.save(out_path)
+    return SignInRenderResult(
+        output_path=out_path,
+        page_width_cm=page_width_cm,
+        available_width_cm=available_cm,
+        columns_cm=(col0, col1, col2),
+    )
+
+
+__all__ = [
+    "SignInRow",
+    "SignInDocumentContext",
+    "SignInRenderResult",
+    "render_signin_table",
+    "TITLE_PT",
+    "FONT_PT",
+    "LEFT_RIGHT_MARGIN_CM",
+    "COL0_FIXED_CM",
+    "COL1_FIXED_CM",
+    "HDR_HEIGHT_CM",
+    "DATA_ROW_HEIGHT_CM",
+]


### PR DESCRIPTION
## Summary
- extract the Word rendering logic into a reusable `render_signin_table` helper
- update the JSON-driven sign-in table script to use the shared renderer
- add a CLI for generating sign-in tables directly from Excel files

## Testing
- python -m compileall scripts/actions/siginin_table_from_json.py scripts/actions/siginin_table_from_excel.py scripts/actions/signin_table_render.py

------
https://chatgpt.com/codex/tasks/task_e_68d35c67f14083319a1c484f297628fa